### PR TITLE
Allow specifying Dockerfile by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,16 @@ You can run a job like this:
 echo -e "FROM busybox\nRUN date\n" > Dockerfile.test
 dune exec -- ocluster-client \
   submit ./capnp-secrets/submission.cap \
+  --cache-hint tutorial \
   --pool=linux-x86_64 \
-  Dockerfile.test
+  --local-dockerfile Dockerfile.test
 ```
 
 The client will display the log output from the job as it arrives.
+
+The scheduler will remember the cache-hint. If you submit the job again with
+the same hint, it will try to schedule it on the same worker, which will be
+faster.
 
 Unlike `docker build`, it does not transfer the current directory as the build context.
 Instead, you can give a Git repository and a commit. The worker will clone the repository
@@ -99,10 +104,15 @@ and checkout the commit, using that as the Docker build context. e.g.
 ```
 dune exec -- ocluster-client \
   submit ./capnp-secrets/submission.cap \
+  --cache-hint tutorial \
   --pool=linux-x86_64 \
-  Dockerfile \
-  https://github.com/ocurrent/ocluster-scheduler.git cf4b43be2739b0d41924890a63e7a1fa5a2f1e3c
+  --local-dockerfile Dockerfile \
+  https://github.com/ocurrent/ocluster.git ac619d2083bb15e0c408e4cd0e3ef7135670cfd5
 ```
+
+Instead of using `--local-dockerfile`, you could also use `--context-dockerfile=Dockerfile` to
+tell the builder to read the Dockerfile from the source commit (this is the default if you don't
+specify `--local-dockerfile`).
 
 If you list multiple commit hashes then the builder will merge them together.
 This is useful for e.g. testing a pull request merged with the master branch's head.

--- a/api/docker.mli
+++ b/api/docker.mli
@@ -19,7 +19,7 @@ module Spec : sig
   }
 
   type t = {
-    dockerfile : string;       (** The contents of a Dockerfile to build. *)
+    dockerfile : [`Contents of string | `Path of string];
     build_args : string list;  (** "--build-arg" arguments. *)
     push_to : push option;     (** Where to upload the resulting image. *)
   }

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -1,8 +1,13 @@
 @0x8378b104cef5b2eb;
 
 struct DockerBuild {
-  dockerfile   @0 :Text;
-  # The contents of the Dockerfile to build.
+  dockerfile   :union {
+    contents   @0 :Text;
+    # The contents of the Dockerfile to build.
+
+    path       @5 :Text;
+    # The path of the Dockerfile within the context.
+  }
 
   pushTarget   @1 :Text;
   # If set, the builder will "docker push" to this target on success.

--- a/test/test.ml
+++ b/test/test.ml
@@ -38,7 +38,7 @@ let read_log job =
   aux 0L
 
 let submit service dockerfile =
-  let action = Cluster_api.Submission.docker_build dockerfile in
+  let action = Cluster_api.Submission.docker_build (`Contents dockerfile) in
   Capability.with_ref (Cluster_api.Submission.submit service ~pool:"pool" ~action ~cache_hint:"1" ?src:None) @@ fun job ->
   read_log job >>= fun log ->
   Cluster_api.Job.result job >|= function
@@ -203,7 +203,7 @@ let cancel () =
   let builder = Mock_builder.create () in
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder (Mock_network.sturdy registry);
-  let action = Cluster_api.Submission.docker_build "example" in
+  let action = Cluster_api.Submission.docker_build (`Contents "example") in
   Capability.with_ref (Cluster_api.Submission.submit submission_service ~pool:"pool" ~action ~cache_hint:"1" ?src:None) @@ fun job ->
   let log = read_log job in
   Mock_builder.await builder "example" >>= fun _ ->

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -4,7 +4,8 @@ val run :
                  log:Log_data.t ->
                  src:string ->
                  build_args:string list ->
-                 string -> (string, Process.error) Lwt_result.t) ->
+                 [ `Contents of string | `Path of string ] ->
+                 (string, Process.error) Lwt_result.t) ->
   ?allow_push:string list ->
   capacity:int ->
   name:string ->

--- a/worker/context.ml
+++ b/worker/context.ml
@@ -71,7 +71,7 @@ module Repo = struct
         Process.exec ~switch ~log ["git"; "-C"; local_repo; "remote"; "add"; "origin"; "--mirror=fetch"; "--"; Uri.to_string t.url]
       )
     end >>!= fun () ->
-    Process.exec ~switch ~log ["git"; "-C"; local_repo; "fetch"; "--update-head-ok"; "origin"]
+    Process.exec ~switch ~log ["git"; "-C"; local_repo; "fetch"; "-q"; "--update-head-ok"; "origin"]
 end
 
 let repos = Hashtbl.create 1000

--- a/worker/process.mli
+++ b/worker/process.mli
@@ -10,4 +10,4 @@ val exec :
   ?stdin:string ->
   ?stderr:Lwt_process.redirection ->
   string list ->
-  (unit, error) Lwt_result.t
+  (unit, [> error]) Lwt_result.t


### PR DESCRIPTION
This avoids the need for the client to clone the Git repository if they just want to use the included Dockerfile.