### PR TITLE
Allow queues to be set inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ dune exec -- ocluster-client \
   show ./capnp-secrets/admin.cap linux-x86_64
 ```
 
+To pause a worker, give the pool and the worker's name, e.g.:
+
+```
+dune exec -- ocluster-client \
+  pause ./capnp-secrets/admin.cap linux-x86_64 my-host
+```
+
+A paused worker will not be assigned any more items until it is unpaused, but
+it will continue with any jobs it is already running. Use `unpause` to resume it.
+
+
 ### Publishing the result
 
 You can ask the builder to push the resulting image somewhere. The client provides three options for this:

--- a/api/pool_admin.ml
+++ b/api/pool_admin.ml
@@ -1,7 +1,12 @@
 open Lwt.Infix
 open Capnp_rpc_lwt
 
-let local ~dump =
+type worker_info = {
+  name : string;
+  active : bool;
+}
+
+let local ~dump ~workers ~set_active =
   let module X = Raw.Service.PoolAdmin in
   X.local @@ object
     inherit X.service
@@ -12,6 +17,29 @@ let local ~dump =
       let response, results = Service.Response.create Results.init_pointer in
       Results.state_set results (dump ());
       Service.return response
+
+    method workers_impl _params release_param_caps =
+      let open X.Workers in
+      release_param_caps ();
+      let response, results = Service.Response.create Results.init_pointer in
+      let items = workers () in
+      let arr = Results.workers_init results (List.length items) in
+      items |> List.iteri (fun i { name; active } ->
+          let slot = Capnp.Array.get arr i in
+          let module B = Raw.Builder.WorkerInfo in
+          B.name_set slot name;
+          B.active_set slot active
+        );
+      Service.return response
+
+    method set_active_impl params release_param_caps =
+      let open X.SetActive in
+      let worker = Params.worker_get params in
+      let active = Params.active_get params in
+      release_param_caps ();
+      match set_active worker active with
+      | Ok () -> Service.return_empty ()
+      | Error `Unknown_worker -> Service.fail "Unknown worker"
   end
 
 module X = Raw.Client.PoolAdmin
@@ -22,3 +50,20 @@ let dump t =
   let open X.Dump in
   let request = Capability.Request.create_no_args () in
   Capability.call_for_value_exn t method_id request >|= Results.state_get
+
+let workers t =
+  let open X.Workers in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_value_exn t method_id request >|= fun results ->
+  let module R = Raw.Reader.WorkerInfo in
+  Results.workers_get_list results |> List.map @@ fun worker ->
+  let name = R.name_get worker in
+  let active = R.active_get worker in
+  { name; active }
+
+let set_active t worker active =
+  let open X.SetActive in
+  let request, params = Capability.Request.create Params.init_pointer in
+  Params.worker_set params worker;
+  Params.active_set params active;
+  Capability.call_for_unit_exn t method_id request

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -61,7 +61,13 @@ interface Job {
 }
 
 interface Queue {
-  pop @0 (job :Job) -> (descr :JobDescr);
+  pop       @0 (job :Job) -> (descr :JobDescr);
+
+  setActive @1 (active :Bool) -> ();
+  # When a queue is made inactive any items on it are returned to the main
+  # queue and no new items will be added until it is made active again. This
+  # is useful if a worker needs to stop handling jobs for a while (e.g. to
+  # prune or upgrade), but still wants to provide metrics.
 }
 
 interface Worker {
@@ -82,8 +88,15 @@ interface Submission {
   submit @0 (pool :Text, descr :JobDescr, urgent :Bool) -> (job :Job);
 }
 
+struct WorkerInfo {
+  name   @0 :Text;
+  active @1 :Bool;
+}
+
 interface PoolAdmin {
-  dump @0 () -> (state :Text);
+  dump      @0 () -> (state :Text);
+  workers   @1 () -> (workers : List(WorkerInfo));
+  setActive @2 (worker :Text, active :Bool) -> ();
 }
 
 interface Admin {

--- a/scheduler/pool.mli
+++ b/scheduler/pool.mli
@@ -26,6 +26,19 @@ module Make (Item : S.ITEM) : sig
   val pop : worker -> (Item.t, [> `Finished]) Lwt_result.t
   (** [pop worker] gets the next item for [worker]. *)
 
+  val set_active : worker -> bool -> unit
+  (** [set_active worker active] sets the worker's active flag.
+      When set to [true], items can be added from the main queue.
+      When changed to [false], any entries on the queue are pushed back to the
+      main queue, and the queue stops accepting new items. *)
+
+  val is_active : worker -> bool
+  (** [is_active worker] returns [worker]'s active flag. *)
+
+  val connected_workers : t -> worker Astring.String.Map.t
+  (** [connected_workers t] is the set of workers currently connected, whether active or not,
+      indexed by name. *)
+
   val release : worker -> unit
   (** [release worker] marks [worker] as disconnected.
       [worker] cannot be used again after this (use [register] to get a new one). *)


### PR DESCRIPTION
The command-line client now has `pause` and `unpause` commands to control this. A paused worker will not be assigned any more items until it is unpaused, but it will continue with any jobs is it already running.

Also, remove the `will_cache` hashtable. We only add something to a worker queue if it's either already cached (and `will_cache` isn't needed), or the worker is ready and will add the item to `cache` immediately anyway.