### PR TITLE
Add --prune-threshold to build workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,15 @@ contains a secret token granting it access.
 To run the build service locally:
 
 ```
-dune exec -- ocluster-worker ./capnp-secrets/pool-linux-x86_64.cap --name=my-host --capacity=1
+dune exec -- ocluster-worker ./capnp-secrets/pool-linux-x86_64.cap \
+  --name=my-host --capacity=1 --prune-threshold=20
 ```
 
 Each builder must be given a unique name.
 `capacity` controls how many jobs this worker will build at once.
+`prune-threshold` says how much free space must be available in the
+`/var/lib/docker` partition before the worker will run `docker system prune -af`.
+If not given, then the worker will not monitor free space.
 
 The builder connects to the scheduler and waits for jobs.
 You should see `worker [INFO] Requesting a new job...` in the worker log,

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -7,6 +7,7 @@ val run :
                  [ `Contents of string | `Path of string ] ->
                  (string, Process.error) Lwt_result.t) ->
   ?allow_push:string list ->
+  ?prune_threshold:float ->
   capacity:int ->
   name:string ->
   Cluster_api.Raw.Client.Registration.t Capnp_rpc_lwt.Sturdy_ref.t ->
@@ -15,7 +16,8 @@ val run :
     The builder registers using the unique ID [name].
     @param switch Turning this off causes the builder to exit (for unit-tests)
     @param docker_build Used to override the default build action (for unit-tests)
-    @param allow_push Docker repositories to which results can be pushed *)
+    @param allow_push Docker repositories to which results can be pushed
+    @param prune_threshold Stop and run "docker system prune -af" if free-space is less than this percentage (0 to 100). *)
 
 module Process = Process
 module Log_data = Log_data


### PR DESCRIPTION
If available disk space on the Docker partition falls below this level, the worker marks itself as inactive, finishes any jobs in progress, then runs `docker system prune -af` to recover space.