### PR TITLE
Make including the .git directory in the context optional

### DIFF
--- a/api/docker.ml
+++ b/api/docker.ml
@@ -40,6 +40,7 @@ module Spec = struct
     build_args : string list;
     squash : bool;
     buildkit: bool;
+    include_git : bool [@default true];
   } [@@deriving yojson]
 
   type t = {
@@ -52,6 +53,7 @@ module Spec = struct
     build_args = [];
     squash = false;
     buildkit = false;
+    include_git = false;
   }
 
   let init b { dockerfile; options; push_to } =
@@ -63,10 +65,11 @@ module Spec = struct
       | `Contents contents -> Dockerfile.contents_set dockerfile_b contents
       | `Path path -> Dockerfile.path_set dockerfile_b path
     end;
-    let { build_args; squash; buildkit } = options in
+    let { build_args; squash; buildkit; include_git } = options in
     DB.build_args_set_list b build_args |> ignore;
     DB.squash_set b squash;
     DB.buildkit_set b buildkit;
+    DB.include_git_set b include_git;
     push_to |> Option.iter (fun { target; user; password } ->
         DB.push_target_set b (Image_id.to_string target);
         DB.push_user_set b user;
@@ -88,7 +91,8 @@ module Spec = struct
     let build_args = R.build_args_get_list r in
     let squash = R.squash_get r in
     let buildkit = R.buildkit_get r in
-    let options = { build_args; squash; buildkit } in
+    let include_git = R.include_git_get r in
+    let options = { build_args; squash; buildkit; include_git } in
     let push_to =
       match target, user, password with
       | "", "", "" -> None

--- a/api/docker.mli
+++ b/api/docker.mli
@@ -22,6 +22,7 @@ module Spec : sig
     build_args : string list;  (** "--build-arg" arguments. *)
     squash : bool;
     buildkit: bool;
+    include_git : bool;
   } [@@deriving yojson]
 
   type t = {

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -31,6 +31,9 @@ struct DockerBuild {
   # Use BuildKit for the build.
   # Note: buildkit builds shared caches, so clients using such builds must all
   # trust each other not to poison the caches.
+
+  includeGit   @8 :Bool;
+  # If set, include the .git directory in the build context.
 }
 
 struct JobDescr {

--- a/bin/client.ml
+++ b/bin/client.ml
@@ -243,6 +243,13 @@ let buildkit =
     ~doc:"Whether to use BuildKit to build"
     ["buildkit"]
 
+let include_git =
+  Arg.value @@
+  Arg.flag @@
+  Arg.info
+    ~doc:"Include the .git clone in the build context"
+    ["include-git"]
+
 let push_to =
   let make target user password =
     match target, user, password with
@@ -256,10 +263,10 @@ let push_to =
   Term.(pure make $ push_to $ push_user $ push_password_file)
 
 let build_options =
-  let make build_args squash buildkit =
-    { Cluster_api.Docker.Spec.build_args; squash; buildkit }
+  let make build_args squash buildkit include_git =
+    { Cluster_api.Docker.Spec.build_args; squash; buildkit; include_git }
   in
-  Term.(pure make $ build_args $ squash $ buildkit)
+  Term.(pure make $ build_args $ squash $ buildkit $ include_git)
 
 let submit =
   let doc = "Submit a build to the scheduler" in

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -273,7 +273,7 @@ let docker_build ~switch ~log ~src ~options dockerfile =
            | Ok path -> Lwt_result.return path
            | Error e -> Lwt_result.fail e
        end >>!= fun dockerpath ->
-       let { Cluster_api.Docker.Spec.build_args; squash; buildkit } = options in
+       let { Cluster_api.Docker.Spec.build_args; squash; buildkit; include_git = _ } = options in
        let args =
          List.concat_map (fun x -> ["--build-arg"; x]) build_args
          @ (if squash then ["--squash"] else [])


### PR DESCRIPTION
Copying it is slow and can interfere with docker's build caching. Just enable it where needed (e.g. for the base image builder).