### PR TITLE
Add Ticket to represent queued request

### DIFF
--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -101,8 +101,17 @@ interface Registration {
   register @0 (name :Text, worker :Worker) -> (queue :Queue);
 }
 
+interface Ticket {
+  job    @0 () -> (job :Job);
+  # The job object at the build node. This will be a promise until the job has been accepted.
+
+  cancel @1 () -> ();
+  # Cancel the job request. If the job has already been assigned to a worker, this cancels
+  # the job itself.
+}
+
 interface Submission {
-  submit @0 (pool :Text, descr :JobDescr, urgent :Bool) -> (job :Job);
+  submit @0 (pool :Text, descr :JobDescr, urgent :Bool) -> (ticket :Ticket);
 }
 
 struct WorkerInfo {

--- a/api/submission.ml
+++ b/api/submission.ml
@@ -11,10 +11,10 @@ let local ~submit =
       let pool = Params.pool_get params in
       let descr = Params.descr_get params in
       let urgent = Params.urgent_get params in
-      let job = submit ~pool ~urgent descr in
+      let ticket = submit ~pool ~urgent descr in
       let response, results = Service.Response.create Results.init_pointer in
-      Results.job_set results (Some job);
-      Capability.dec_ref job;
+      Results.ticket_set results (Some ticket);
+      Capability.dec_ref ticket;
       Service.return response
   end
 
@@ -48,4 +48,4 @@ let submit ?src ?(urgent=false) t ~pool ~action ~cache_hint =
       let _ : _ Capnp.Array.t = JD.commits_set_list b commits in
       JD.repository_set b repo;
     );
-  Capability.call_for_caps t method_id request Results.job_get_pipelined
+  Capability.call_for_caps t method_id request Results.ticket_get_pipelined

--- a/api/ticket.ml
+++ b/api/ticket.ml
@@ -1,0 +1,41 @@
+open Capnp_rpc_lwt
+
+type t = Raw.Service.Ticket.t Capability.t
+
+let ( >>!= ) = Lwt_result.bind
+
+let local ~job ~cancel ~release =
+  let module X = Raw.Service.Ticket in
+  X.local @@ object
+    inherit X.service
+
+    method job_impl _params release_param_caps =
+      let open X.Job in
+      release_param_caps ();
+      let response, results = Service.Response.create Results.init_pointer in
+      Results.job_set results (Some job);
+      Service.return response
+
+    method cancel_impl _params release_param_caps =
+      release_param_caps ();
+      Service.return_lwt @@ fun () ->
+      cancel () >>!= fun () ->
+      let response = Service.Response.create_empty () in
+      Lwt_result.return response
+
+    method! release =
+      Capability.dec_ref job;
+      release ()
+  end
+
+module X = Raw.Client.Ticket
+
+let job t =
+  let open X.Job in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_caps t method_id request Results.job_get_pipelined
+
+let cancel t =
+  let open X.Cancel in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_unit t method_id request

--- a/bin/client.ml
+++ b/bin/client.ml
@@ -50,7 +50,8 @@ let submit submission_path pool dockerfile repository commits cache_hint urgent 
       `Contents data
   end >>= fun dockerfile ->
   let action = Cluster_api.Submission.docker_build ?push_to ~options dockerfile in
-  let job = Cluster_api.Submission.submit submission_service ~urgent ~pool ~action ~cache_hint ?src in
+  Capability.with_ref (Cluster_api.Submission.submit submission_service ~urgent ~pool ~action ~cache_hint ?src) @@ fun ticket ->
+  Capability.with_ref (Cluster_api.Ticket.job ticket) @@ fun job ->
   let result = Cluster_api.Job.result job in
   Fmt.pr "Tailing log:@.";
   tail job 0L >>= fun () ->

--- a/scheduler/cluster_scheduler.ml
+++ b/scheduler/cluster_scheduler.ml
@@ -39,12 +39,20 @@ module Pool_api = struct
     let workers = Hashtbl.create 10 in
     { pool; workers }
 
-  let submit t ~urgent (descr : Cluster_api.Queue.job_desc) : Cluster_api.Job.t =
+  let submit t ~urgent (descr : Cluster_api.Queue.job_desc) : Cluster_api.Ticket.t =
     let job, set_job = Capability.promise () in
+    let cancel () =
+      Log.info (fun f -> f "TODO: cancel queued job");
+      Cluster_api.Job.cancel job
+    in
+    let release () =
+      Log.info (fun f -> f "TODO: cancel job if still queued")
+    in
+    let ticket = Cluster_api.Ticket.local ~job ~cancel ~release in
     Log.info (fun f -> f "Received new job request (urgent=%b)" urgent);
     let item = { Item.descr; set_job } in
     Pool.submit ~urgent t.pool item;
-    job
+    ticket
 
   let pop q ~job =
     Pool.pop q >|= function

--- a/test/test.ml
+++ b/test/test.ml
@@ -39,7 +39,8 @@ let read_log job =
 
 let submit service dockerfile =
   let action = Cluster_api.Submission.docker_build (`Contents dockerfile) in
-  Capability.with_ref (Cluster_api.Submission.submit service ~pool:"pool" ~action ~cache_hint:"1" ?src:None) @@ fun job ->
+  Capability.with_ref (Cluster_api.Submission.submit service ~pool:"pool" ~action ~cache_hint:"1" ?src:None) @@ fun ticket ->
+  Capability.with_ref (Cluster_api.Ticket.job ticket) @@ fun job ->
   read_log job >>= fun log ->
   Cluster_api.Job.result job >|= function
   | Ok "" -> log
@@ -204,7 +205,8 @@ let cancel () =
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder (Mock_network.sturdy registry);
   let action = Cluster_api.Submission.docker_build (`Contents "example") in
-  Capability.with_ref (Cluster_api.Submission.submit submission_service ~pool:"pool" ~action ~cache_hint:"1" ?src:None) @@ fun job ->
+  Capability.with_ref (Cluster_api.Submission.submit submission_service ~pool:"pool" ~action ~cache_hint:"1" ?src:None) @@ fun ticket ->
+  Capability.with_ref (Cluster_api.Ticket.job ticket) @@ fun job ->
   let log = read_log job in
   Mock_builder.await builder "example" >>= fun _ ->
   Cluster_api.Job.cancel job >>= fun cancel_result ->


### PR DESCRIPTION
The idea is to allow clients to cancel jobs while they're still queued. However, this isn't implemented yet - this commit just changes the API to allow it in future.

(doing this change in stages to avoid breaking clients)