### PR TITLE
Turn on experimental Docker features in worker client

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -12,4 +12,5 @@ FROM debian:10
 RUN apt-get update && apt-get install docker.io libev4 curl gnupg2 git libsqlite3-dev ca-certificates netbase -y --no-install-recommends
 WORKDIR /var/lib/ocluster-worker
 ENTRYPOINT ["/usr/local/bin/ocluster-worker"]
+RUN mkdir ~/.docker && echo '{"experimental": "enabled"}' > ~/.docker/config.json
 COPY --from=build /src/_build/install/default/bin/ocluster-worker /usr/local/bin/


### PR DESCRIPTION
Needed to use BuildKit.