### PR TITLE
Wait for release function to finish before dropping job reference

### DIFF
--- a/api/ticket.ml
+++ b/api/ticket.ml
@@ -23,9 +23,10 @@ let local ~job ~cancel ~release =
       let response = Service.Response.create_empty () in
       Lwt_result.return response
 
+    (* Note: we keep job alive until *after* calling [release]. *)
     method! release =
-      Capability.dec_ref job;
-      release ()
+      release ();
+      Capability.dec_ref job
   end
 
 module X = Raw.Client.Ticket


### PR DESCRIPTION
Otherwise, if the ticket is released while the job is still queued then our attempt to break it fails.