### PR TITLE
use the public ocluster-api library name

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -2,4 +2,4 @@
  (public_names ocluster-scheduler ocluster-client ocluster-worker)
  (package ocluster)
  (names scheduler client worker)
- (libraries cluster_api logs.fmt fmt.tty capnp-rpc-unix cluster_scheduler cluster_worker prometheus-app.unix db))
+ (libraries ocluster-api logs.fmt fmt.tty capnp-rpc-unix cluster_scheduler cluster_worker prometheus-app.unix db))

--- a/scheduler/dune
+++ b/scheduler/dune
@@ -1,3 +1,3 @@
 (library
  (name cluster_scheduler)
- (libraries cluster_api logs capnp-rpc-lwt lwt-dllist prometheus db))
+ (libraries ocluster-api logs capnp-rpc-lwt lwt-dllist prometheus db))

--- a/worker/dune
+++ b/worker/dune
@@ -1,3 +1,3 @@
 (library
  (name cluster_worker)
- (libraries cluster_api digestif fpath logs capnp-rpc-lwt lwt.unix prometheus-app cohttp-lwt-unix))
+ (libraries ocluster-api digestif fpath logs capnp-rpc-lwt lwt.unix prometheus-app cohttp-lwt-unix))


### PR DESCRIPTION
This allows `opam pin` to work with the repository, which currently
fails due to the ocluster-api library being in a separate opam
package (and hence not picked up when `dune build -p` is used.