### PR TITLE
Fix log limiting

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -23,6 +23,7 @@
  (name ocluster)
  (synopsis "Distribute build jobs to workers")
  (depends
+  dune-build-info
   (ocluster-api (= :version))
   lwt
   (capnp-rpc-unix (>= 0.8.0))

--- a/worker/log_data.ml
+++ b/worker/log_data.ml
@@ -30,8 +30,8 @@ let rec stream t ~start =
     let chunk = min avail max_chunk_size in
     let next = Int64.add start chunk in
     let start = Int64.to_int start in
-    let avail = Int64.to_int avail in
-    Lwt.return (Buffer.sub t.data start avail, next)
+    let chunk = Int64.to_int chunk in
+    Lwt.return (Buffer.sub t.data start chunk, next)
   )
 
 let write t data =


### PR DESCRIPTION
Discovered by @samoht.

Also, add missing `dune-build-info` dependency.