### PR TITLE
Auto-prune OBuilder store too

### DIFF
--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -373,15 +373,15 @@ let self_update ~update t =
     )
 
 let run ?switch ?build ?(allow_push=[]) ?prune_threshold ?obuilder ~update ~capacity ~name registration_service =
-  begin match obuilder with
-    | None -> Lwt.return_none
-    | Some config -> Obuilder_build.create config >|= Option.some
-  end >>= fun obuilder ->
   begin match prune_threshold with
     | None -> Log.info (fun f -> f "Prune threshold not set. Will not check for low disk-space!")
     | Some frac when frac < 0.0 || frac > 100.0 -> Fmt.invalid_arg "prune_threshold must be in the range 0 to 100"
     | Some _ -> ()
   end;
+  begin match obuilder with
+    | None -> Lwt.return_none
+    | Some config -> Obuilder_build.create ?prune_threshold config >|= Option.some
+  end >>= fun obuilder ->
   let build =
     match build with
     | Some x -> x

--- a/worker/df.ml
+++ b/worker/df.ml
@@ -1,0 +1,13 @@
+open Lwt.Infix
+
+let free_space_percent path =
+  Lwt_process.pread ("", [| "df"; path; "--output=pcent" |]) >|= fun lines ->
+  match String.split_on_char '\n' (String.trim lines) with
+  | [_; result] ->
+    let used =
+      try Scanf.sscanf result " %f%%" Fun.id
+      with _ -> Fmt.failwith "Expected %S, got %S" "xx%" result
+    in
+    100. -. used
+  | _ ->
+    Fmt.failwith "Expected two lines from df, but got:@,%S" lines

--- a/worker/obuilder_build.ml
+++ b/worker/obuilder_build.ml
@@ -1,10 +1,16 @@
 open Lwt.Infix
 
-type t =
-  switch:Lwt_switch.t ->
-  log:Log_data.t ->
-  spec:Obuilder.Spec.stage ->
-  src_dir:string -> (string, [ `Cancelled | `Msg of string ]) result Lwt.t
+let prune_margin = 600.0        (* Don't prune anything used less than 10 minutes ago *)
+
+type builder = Builder : (module Obuilder.BUILDER with type t = 'a) * 'a -> builder
+
+type t = {
+  builder : builder;
+  spec : Obuilder.Store_spec.t;
+  mutable pruning : bool;
+  cond : unit Lwt_condition.t;          (* Fires when we finish pruning *)
+  prune_threshold : float option;
+}
 
 module Sandbox = Obuilder.Runc_sandbox
 
@@ -16,14 +22,76 @@ let log_to log_data tag msg =
   | `Note -> Log_data.info log_data "%s" msg
   | `Output -> Log_data.write log_data msg
 
-let create spec =
+let create ?prune_threshold spec =
   Obuilder.Store_spec.to_store spec >|= fun (Store ((module Store), store)) ->
   let sandbox = Sandbox.create ~runc_state_dir:(Store.state_dir store / "runc") in
   let module Builder = Obuilder.Builder(Store)(Sandbox) in
-  let builder = Builder.v ~store ~sandbox in
-  fun ~switch ~log ~spec ~src_dir ->
-    let log = log_to log in
-    let context = Obuilder.Context.v ~switch ~log ~src_dir () in
-    Builder.build builder context spec
+  let builder = Builder ((module Builder), Builder.v ~store ~sandbox) in
+  { builder; pruning = false; prune_threshold; spec; cond = Lwt_condition.create () }
 
-let build t = t
+(* Prune [t] until [path]'s free space rises above [prune_threshold]. *)
+let do_prune ~path ~prune_threshold t =
+  let Builder ((module Builder), builder) = t.builder in
+  let rec aux () =
+    let stop = Unix.gettimeofday () -. prune_margin |> Unix.gmtime in
+    let limit = 100 in
+    Builder.prune builder ~before:stop limit >>= fun n ->
+    Df.free_space_percent path >>= fun free ->
+    Log.info (fun f -> f "OBuilder partition: %.0f%% free after pruning %d items" free n);
+    if free > prune_threshold then Lwt.return_unit      (* Space problem is fixed! *)
+    else if n < limit then (
+      Log.warn (fun f -> f "Out of space, but nothing left to prune! (will wait and then retry)");
+      Lwt_unix.sleep 600.0 >>= aux
+    ) else (
+      (* Continue pruning *)
+      aux ()
+    )
+  in
+  aux ()
+
+let store_path t =
+  match t.spec with
+  | `Btrfs path -> path
+  | `Zfs pool -> "/" ^ pool
+
+(* Check the free space in [t]'s store.
+   If less than [t.prune_threshold], spawn a prune operation (if not already running).
+   If less than half that is remaining, also wait for it to finish.
+   Returns once there is enough free space to proceed. *)
+let check_free_space t =
+  match t.prune_threshold with
+  | None -> Lwt.return_unit
+  | Some prune_threshold ->
+    let path = store_path t in
+    let rec aux () =
+      Df.free_space_percent path >>= fun free ->
+      Log.info (fun f -> f "OBuilder partition: %.0f%% free" free);
+      (* If we're low on space, spawn a pruning thread. *)
+      if free < prune_threshold && t.pruning = false then (
+        t.pruning <- true;
+        Lwt.async (fun () ->
+            Lwt.finalize
+              (fun () -> do_prune ~path ~prune_threshold t)
+              (fun () ->
+                 Lwt.pause () >|= fun () ->
+                 t.pruning <- false;
+                 Lwt_condition.broadcast t.cond ()
+              )
+          );
+      );
+      if free < prune_threshold /. 2.0 then (
+        assert (t.pruning);
+        Log.info (fun f -> f "OBuilder space very low. Waiting for prune to finish...");
+        Lwt_condition.wait t.cond >>= aux
+      ) else (
+        Lwt.return_unit
+      )
+    in
+    aux ()
+
+let build t ~switch ~log ~spec ~src_dir =
+  check_free_space t >>= fun () ->
+  let log = log_to log in
+  let context = Obuilder.Context.v ~switch ~log ~src_dir () in
+  let Builder ((module Builder), builder) = t.builder in
+  Builder.build builder context spec

--- a/worker/obuilder_build.mli
+++ b/worker/obuilder_build.mli
@@ -1,6 +1,6 @@
 type t
 
-val create : Obuilder.Store_spec.t -> t Lwt.t
+val create : ?prune_threshold:float -> Obuilder.Store_spec.t -> t Lwt.t
 
 val build : t ->
   switch:Lwt_switch.t ->


### PR DESCRIPTION
When free space is less than the prune threshold, spawn a prune thread.
When less than half that is free, block builds until more space is available.