### PR TITLE
Make state directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ To run the build service locally:
 
 ```
 dune exec -- ocluster-worker ./capnp-secrets/pool-linux-x86_64.cap \
+  --state-dir=/var/lib/ocluster-worker \
   --name=my-host --capacity=1 --prune-threshold=20
 ```
 

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -16,9 +16,10 @@ val run :
   update:(unit -> (unit -> unit Lwt.t) Lwt.t) ->
   capacity:int ->
   name:string ->
+  state_dir:string ->
   Cluster_api.Raw.Client.Registration.t Capnp_rpc_lwt.Sturdy_ref.t ->
   unit Lwt.t
-(** [run ~capacity ~name registry] runs a builder that connects to registry and runs up to [capacity] jobs at once.
+(** [run ~capacity ~name ~state_dir registry] runs a builder that connects to registry and runs up to [capacity] jobs at once.
     The builder registers using the unique ID [name].
     @param switch Turning this off causes the builder to exit (for unit-tests)
     @param build Used to override the default build action (for unit-tests)
@@ -27,6 +28,7 @@ val run :
                   then return a function to do the actual update. This is so that the first part can run while the node
                   finishes its remaining jobs. The second part is called once all jobs are finished.
                   If the second function returns, the process will exit.
+    @param state_dir A persistent directory for Git caches, etc.
     @param prune_threshold Stop and run "docker system prune -af" if free-space is less than this percentage (0 to 100). *)
 
 module Process = Process

--- a/worker/context.mli
+++ b/worker/context.mli
@@ -16,10 +16,16 @@
     4. Finally, we move all the checked-out files to our desired temporary
        directory (on the same FS) and release the repository lock. *)
 
+type t
+
+val v : state_dir:string -> t
+(** @param state_dir Used for temporary checkouts and Git cache. *)
+
 val with_build_context :
+  t ->
   log:Log_data.t ->
   Cluster_api.Raw.Reader.JobDescr.t ->
   (string -> ('a, [`Cancelled | `Msg of string]) Lwt_result.t) ->
   ('a, [`Cancelled | `Msg of string]) Lwt_result.t
-(** [with_build_context ~log descr fn] runs [fn dir], where [dir] is a
+(** [with_build_context t ~log descr fn] runs [fn dir], where [dir] is a
     temporary directory containing the requested build context. *)


### PR DESCRIPTION
Previously, we just stored things under `./var`, but this is not very obvious. Instead, take this location as a command-line argument.