### PR TITLE
Use debian:10 for base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocurrent/opam:ubuntu-20.04-ocaml-4.10@sha256:be90dc531fa6693060f65576f587cd38a031370d8e8655144f5cf6f9433ba3c6 AS build
+FROM ocurrent/opam:debian-10-ocaml-4.10@sha256:12fac4e3520657aa72074d2a3b2658776d4b3ce486c930099c996d478c3a2501 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
 RUN cd ~/opam-repository && git pull origin -q master && git reset --hard 3332c004db65ef784f67efdadc50982f000b718f && opam update
 COPY --chown=opam ocluster-api.opam ocluster.opam /src/
@@ -9,7 +9,7 @@ RUN opam install -y --deps-only .
 ADD --chown=opam . .
 RUN opam config exec -- dune build ./_build/install/default/bin/ocluster-scheduler
 
-FROM ubuntu:20.04
+FROM debian:10
 RUN apt-get update && apt-get install libev4 libsqlite3-0 -y --no-install-recommends
 WORKDIR /var/lib/ocluster-scheduler
 ENTRYPOINT ["/usr/local/bin/ocluster-scheduler"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM ocurrent/opam:ubuntu-20.04-ocaml-4.10@sha256:be90dc531fa6693060f65576f587cd38a031370d8e8655144f5cf6f9433ba3c6 AS build
+FROM ocurrent/opam:debian-10-ocaml-4.10@sha256:12fac4e3520657aa72074d2a3b2658776d4b3ce486c930099c996d478c3a2501 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
 RUN cd ~/opam-repository && git pull origin -q master && git reset --hard 3332c004db65ef784f67efdadc50982f000b718f && opam update
 COPY --chown=opam ocluster-api.opam ocluster.opam /src/
@@ -9,7 +9,7 @@ RUN opam install -y --deps-only .
 ADD --chown=opam . .
 RUN opam config exec -- dune build ./_build/install/default/bin/ocluster-worker
 
-FROM ubuntu:20.04
+FROM debian:10
 RUN apt-get update && apt-get install docker.io libev4 curl gnupg2 git libsqlite3-dev ca-certificates netbase -y --no-install-recommends
 WORKDIR /var/lib/ocluster-worker
 ENTRYPOINT ["/usr/local/bin/ocluster-worker"]


### PR DESCRIPTION
We were using Ubuntu for ppc64 Docker binaries. However, we now plan to run the workers natively, so this doesn't matter. Instead, we need binaries that are compatible with more versions of glibc, which the older Debian release should provide.