### PR TITLE
Try git fetch --recurse-submodules=no

### DIFF
--- a/worker/context.ml
+++ b/worker/context.ml
@@ -74,7 +74,8 @@ module Repo = struct
     (* This reset might avoid `fatal: cannot chdir to '../../../ocurrent': No such file or directory` errors *)
     Process.check_call ~label:"git-reset" ~switch ~log ["git"; "-C"; local_repo; "reset"; "--hard"] >>!= fun () ->
     Process.check_call ~label:"git-submodule-deinit" ~switch ~log ["git"; "-C"; local_repo; "submodule"; "deinit"; "--all"; "-f"] >>!= fun () ->
-    Process.check_call ~label:"git-fetch" ~switch ~log ["git"; "-C"; local_repo; "fetch"; "-q"; "--update-head-ok"; "origin"]
+    Process.check_call ~label:"git-fetch" ~switch ~log
+      ["git"; "-C"; local_repo; "fetch"; "-q"; "--update-head-ok"; "--recurse-submodules=no"; "origin"]
 end
 
 let repos = Hashtbl.create 1000


### PR DESCRIPTION
Maybe this will fix the occasional error like this:

    Building on ampere1.ocamllabs.io
    HEAD is now at c9aa257 Replace pin-depends with submodules
    Cleared directory 'ocluster'
    Submodule 'ocluster' (https://github.com/ocurrent/ocluster.git) unregistered for path 'ocluster'
    Cleared directory 'ocurrent'
    Submodule 'ocurrent' (https://github.com/ocurrent/ocurrent.git) unregistered for path 'ocurrent'
    fatal: not a git repository: '.git'
    fatal: not a git repository: '.git'
    fatal: cannot chdir to '../../../../../ocluster/obuilder': No such file or directory
    fatal: cannot chdir to '../../../../../ocluster/obuilder': No such file or directory