### PR TITLE
Allow pushing to targets without logging in

### DIFF
--- a/api/docker.mli
+++ b/api/docker.mli
@@ -14,8 +14,7 @@ end
 module Spec : sig
   type push = {
     target : Image_id.t;
-    user : string;
-    password : string;
+    auth : (string * string) option;
   }
 
   type options = {

--- a/bin/client.ml
+++ b/bin/client.ml
@@ -294,12 +294,16 @@ let include_git =
 let push_to =
   let make target user password =
     match target, user, password with
-    | None, _, _ -> None
+    | None, None, None -> None
+    | None, _, _ ->
+      Fmt.failwith "Must use --push-to with --push-user/--push-password"
     | Some target, Some user, Some password_file ->
       let password = read_first_line password_file in
-      Some { Cluster_api.Docker.Spec.target; user; password }
-    | Some _, None, _ -> Fmt.failwith "Must use --push-user with --push-to"
-    | Some _, Some _, None -> Fmt.failwith "Must use --push-password with --push-to"
+      Some { Cluster_api.Docker.Spec.target; auth = Some (user, password) }
+    | Some target, None, None ->
+      Some { Cluster_api.Docker.Spec.target; auth = None }
+    | _, None, Some _
+    | _, Some _, None -> Fmt.failwith "Must use --push-user with --push-password"
   in
   Term.(pure make $ push_to $ push_user $ push_password_file)
 

--- a/ocurrent-plugin/current_ocluster.ml
+++ b/ocurrent-plugin/current_ocluster.ml
@@ -63,9 +63,9 @@ module Op = struct
   let build t job { Key.dockerfile; src; options; pool; push_target } =
     let push_to =
       match push_target, t.push_auth with
-      | Some target, Some (user, password) ->
+      | Some target, auth ->
         Current.Job.log job "Will push staging image to %a" Cluster_api.Docker.Image_id.pp target;
-        Some { Cluster_api.Docker.Spec.target; user; password }
+        Some { Cluster_api.Docker.Spec.target; auth }
       | _ ->
         None
     in


### PR DESCRIPTION
Relaxes the requirement for a user and password to be specified with a target. If a user is specified, a password must be as well.

This allows pushing to local registries, for example.