### PR TITLE
Don't require conf_libev on Windows

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@
   (capnp-rpc-unix (>= 0.8.0))
   logs
   fmt
-  conf-libev
+  (conf-libev (<> :os "win32"))
   digestif
   fpath
   lwt-dllist

--- a/ocluster.opam
+++ b/ocluster.opam
@@ -13,7 +13,7 @@ depends: [
   "capnp-rpc-unix" {>= "0.8.0"}
   "logs"
   "fmt"
-  "conf-libev"
+  "conf-libev" {os != "win32"}
   "digestif"
   "fpath"
   "lwt-dllist"


### PR DESCRIPTION
Full consequences of this aren't (yet) entirely clear, but the worker definitely works without it!