### PR TITLE
Don't include cache hints database in "show" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Workers register themselves by connecting to the scheduler (and workers do not n
 
 The scheduler can manage multiple pools (e.g. `linux-x86_64` and `linux-arm32`).
 Clients say which pool should handle their requests.
-At the moment, the only build type provided is building a Dockerfile in the context of some Git commit.
-The scheduler tries to schedule similar builds on the same machine, to benefit from Docker's build caching.
+At the moment, two build types are provided: building a Dockerfile, or building an [OBuilder][] spec.
+In either case, the build may done in the context of some Git commit.
+The scheduler tries to schedule similar builds on the same machine, to benefit from caching.
 
 ## The scheduler service
 
@@ -245,7 +246,7 @@ The endpoints available are:
 - `http://...:PORT/pool/{pool}/worker/{worker}/metrics` provides the metrics for the given worker
 - `http://...:PORT/pool/{pool}/worker/{worker}/host-metrics` gets the worker's prometheus-node-exporter metrics
 
-The worker agent and worker host metrics are fetched over the workers Cap'n Proto connection, so there is no need
+The worker agent and worker host metrics are fetched over the worker's Cap'n Proto connection, so there is no need
 to allow incoming network connections to the workers for this.
 
 [OBuilder]: https://github.com/ocurrent/obuilder

--- a/api/pool_admin.ml
+++ b/api/pool_admin.ml
@@ -6,16 +6,16 @@ type worker_info = {
   active : bool;
 }
 
-let local ~dump ~workers ~worker ~set_active ~update =
+let local ~show ~workers ~worker ~set_active ~update =
   let module X = Raw.Service.PoolAdmin in
   X.local @@ object
     inherit X.service
 
-    method dump_impl _params release_param_caps =
-      let open X.Dump in
+    method show_impl _params release_param_caps =
+      let open X.Show in
       release_param_caps ();
       let response, results = Service.Response.create Results.init_pointer in
-      Results.state_set results (dump ());
+      Results.state_set results (show ());
       Service.return response
 
     method workers_impl _params release_param_caps =
@@ -64,8 +64,8 @@ module X = Raw.Client.PoolAdmin
 
 type t = X.t Capability.t
 
-let dump t =
-  let open X.Dump in
+let show t =
+  let open X.Show in
   let request = Capability.Request.create_no_args () in
   Capability.call_for_value_exn t method_id request >|= Results.state_get
 

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -126,7 +126,7 @@ struct WorkerInfo {
 }
 
 interface PoolAdmin {
-  dump      @0 () -> (state :Text);
+  show      @0 () -> (state :Text);
   workers   @1 () -> (workers : List(WorkerInfo));
   worker    @3 (worker :Text) -> (worker :Worker);
   setActive @2 (worker :Text, active :Bool) -> ();

--- a/bin/client.ml
+++ b/bin/client.ml
@@ -86,7 +86,7 @@ let show cap_path pool =
     List.iter print_endline pools
   | Some pool ->
     Capability.with_ref (Cluster_api.Admin.pool admin_service pool) @@ fun pool ->
-    Cluster_api.Pool_admin.dump pool >|= fun status ->
+    Cluster_api.Pool_admin.show pool >|= fun status ->
     print_endline (String.trim status)
 
 let set_active active cap_path pool worker =

--- a/scheduler/cluster_scheduler.ml
+++ b/scheduler/cluster_scheduler.ml
@@ -101,7 +101,7 @@ module Pool_api = struct
       Some w
 
   let admin_service t =
-    let dump () = Fmt.to_to_string Pool.dump t.pool in
+    let show () = Fmt.to_to_string Pool.show t.pool in
     let workers () =
       Pool.connected_workers t.pool
       |> Astring.String.Map.bindings
@@ -139,7 +139,7 @@ module Pool_api = struct
           in
           Lwt.pick [ aux (); timeout ]
     in
-    Cluster_api.Pool_admin.local ~dump ~workers ~worker:(worker t) ~set_active ~update
+    Cluster_api.Pool_admin.local ~show ~workers ~worker:(worker t) ~set_active ~update
 end
 
 type t = {

--- a/scheduler/pool.ml
+++ b/scheduler/pool.ml
@@ -479,6 +479,11 @@ module Make (Item : S.ITEM) = struct
     | `Ready q ->
       Fmt.pf f "(ready) %a" (dump_queue pp_worker) q
 
+  let show f {pool = _; db = _; main; workers} =
+    Fmt.pf f "@[<v>queue: @[%a@]@,@[<v2>registered:%a@]@]@."
+      dump_main main
+      dump_workers workers
+
   let dump f {pool; db; main; workers} =
     Fmt.pf f "@[<v>queue: @[%a@]@,@[<v2>registered:%a@]@,cached: @[%a@]@]@."
       dump_main main

--- a/scheduler/pool.mli
+++ b/scheduler/pool.mli
@@ -54,5 +54,10 @@ module Make (Item : S.ITEM) : sig
   (** [release worker] marks [worker] as disconnected.
       [worker] cannot be used again after this (use [register] to get a new one). *)
 
+  val show : t Fmt.t
+  (** [show] shows the state of the system, including registered workers and queued jobs. *)
+
   val dump : t Fmt.t
+  (** [dump] is similar to [show], but also dumps the contents of the database.
+      It is probably only useful for unit-tests. *)
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -131,7 +131,7 @@ let admin () =
   Cluster_api.Admin.pools admin >>= fun pools ->
   Alcotest.(check (list string)) "Check pools" ["pool"] pools;
   Capability.with_ref (Cluster_api.Admin.pool admin "pool") @@ fun pool ->
-  Cluster_api.Pool_admin.dump pool >>= fun state ->
+  Cluster_api.Pool_admin.show pool >>= fun state ->
   Logs.info (fun f -> f "Pool state:\n%s" state);
   Lwt.return_unit
 


### PR DESCRIPTION
It's too big to be useful.

Also, update the README.