### PR TITLE
Per-client submission endpoints

### DIFF
--- a/api/admin.ml
+++ b/api/admin.ml
@@ -1,7 +1,9 @@
 open Lwt.Infix
 open Capnp_rpc_lwt
 
-let local ~pools ~pool =
+let ( >>!= ) = Lwt_result.bind
+
+let local ~pools ~pool ~add_client ~remove_client ~list_clients =
   let module X = Raw.Service.Admin in
   X.local @@ object
     inherit X.service
@@ -22,6 +24,34 @@ let local ~pools ~pool =
       Results.pool_set results (Some cap);
       Capability.dec_ref cap;
       Service.return response
+
+    method add_client_impl params release_param_caps =
+      let open X.AddClient in
+      let id = Params.id_get params in
+      release_param_caps ();
+      Service.return_lwt @@ fun () ->
+      add_client id >>!= fun cap ->
+      let response, results = Service.Response.create Results.init_pointer in
+      Results.cap_set results (Some cap);
+      Capability.dec_ref cap;
+      Lwt.return_ok response
+
+    method remove_client_impl params release_param_caps =
+      let open X.RemoveClient in
+      let id = Params.id_get params in
+      release_param_caps ();
+      Service.return_lwt @@ fun () ->
+      remove_client id >>!= fun () ->
+      Lwt_result.return (Service.Response.create_empty ())
+
+    method list_clients_impl _params release_param_caps =
+      let open X.ListClients in
+      release_param_caps ();
+      Service.return_lwt @@ fun () ->
+      list_clients () >>= fun clients ->
+      let response, results = Service.Response.create Results.init_pointer in
+      let _ : _ Capnp.Array.t = Results.clients_set_list results clients in
+      Lwt.return_ok response
   end
 
 module X = Raw.Client.Admin
@@ -39,3 +69,20 @@ let pool t name =
   let request, params = Capability.Request.create Params.init_pointer in
   Params.name_set params name;
   Capability.call_for_caps t method_id request Results.pool_get_pipelined
+
+let add_client t id =
+  let open X.AddClient in
+  let request, params = Capability.Request.create Params.init_pointer in
+  Params.id_set params id;
+  Capability.call_for_caps t method_id request Results.cap_get_pipelined
+
+let remove_client t id =
+  let open X.RemoveClient in
+  let request, params = Capability.Request.create Params.init_pointer in
+  Params.id_set params id;
+  Capability.call_for_unit_exn t method_id request
+
+let list_clients t =
+  let open X.ListClients in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_value_exn t method_id request >|= Results.clients_get_list

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -136,6 +136,17 @@ interface PoolAdmin {
 }
 
 interface Admin {
-  pools @0 () -> (names :List(Text));
-  pool  @1 (name :Text) -> (pool :PoolAdmin);
+  pools        @0 () -> (names :List(Text));
+  pool         @1 (name :Text) -> (pool :PoolAdmin);
+
+  addClient    @2 (id :Text) -> (cap :Submission);
+  # Return a new submission endpoint for client "id".
+  # Returns an error if "id" is already registered.
+
+  removeClient @3 (id :Text) -> (cap :Submission);
+  # Remove a client, so that the sturdy-ref can no longer be used to connect.
+  # The client cannot submit any more jobs after this, though existing jobs
+  # are not cancelled.
+
+  listClients  @4 () -> (clients :List(Text));
 }

--- a/bin/logging.ml
+++ b/bin/logging.ml
@@ -9,7 +9,7 @@ let reporter =
     let k _ = over (); k () in
     let src = Logs.Src.name src in
     msgf @@ fun ?header ?tags:_ fmt ->
-    Fmt.kpf k Fmt.stdout ("%a %a %a @[" ^^ fmt ^^ "@]@.")
+    Fmt.kpf k Fmt.stderr ("%a %a %a @[" ^^ fmt ^^ "@]@.")
       pp_timestamp (Unix.gettimeofday ())
       Fmt.(styled `Magenta string) (Printf.sprintf "%14s" src)
       Logs_fmt.pp_header (level, header)

--- a/scheduler/dune
+++ b/scheduler/dune
@@ -1,3 +1,3 @@
 (library
  (name cluster_scheduler)
- (libraries ocluster-api logs capnp-rpc-lwt lwt-dllist prometheus db lwt.unix))
+ (libraries ocluster-api logs capnp-rpc-lwt capnp-rpc-net lwt-dllist prometheus db lwt.unix))

--- a/scheduler/sqlite_loader.ml
+++ b/scheduler/sqlite_loader.ml
@@ -1,0 +1,98 @@
+open Capnp_rpc_lwt
+
+module Secret = Capnp_rpc_net.Restorer.Id
+
+module Ty = struct
+  type t = ..
+
+  let by_name = Hashtbl.create 10
+  let by_value = Hashtbl.create 10
+
+  let register name t =
+    if Hashtbl.mem by_name name then Fmt.invalid_arg "%S already a type name!" name
+    else if Hashtbl.mem by_value t then Fmt.invalid_arg "Type already registered"
+    else (
+      Hashtbl.add by_name name t;
+      Hashtbl.add by_value t name
+    )
+
+  let to_string : t -> string = Hashtbl.find by_value
+  let of_string : string -> t = Hashtbl.find by_name
+
+  let pp = Fmt.using (Hashtbl.find_opt by_value) Fmt.(option ~none:(unit "(unregistered type)") string)
+end
+
+type digest = string
+
+type descr = (Ty.t * string) (** (type, args) *)
+
+type t = {
+  db : Sqlite3.db;
+  make_sturdy : Secret.t -> Uri.t;
+  load : validate:(unit -> bool) -> sturdy_ref:([`Generic] Sturdy_ref.t) -> descr -> Capnp_rpc_net.Restorer.resolution Lwt.t;
+  add : Sqlite3.stmt;
+  remove : Sqlite3.stmt;
+  lookup_by_hash : Sqlite3.stmt;
+  lookup_by_descr : Sqlite3.stmt;
+  list_by_type : Sqlite3.stmt;
+}
+
+let create ~make_sturdy ~load db =
+  Sqlite3.exec db "CREATE TABLE IF NOT EXISTS sturdy_refs ( \
+                   hash       BLOB NOT NULL, \
+                   type       TEXT NOT NULL, \
+                   args       BLOB NOT NULL, \
+                   created    DATETIME NOT NULL, \
+                   PRIMARY KEY (hash))" |> Db.or_fail ~cmd:"create table";
+  Sqlite3.exec db "CREATE INDEX IF NOT EXISTS sturdy_refs_rev ON sturdy_refs (type, args)" |> Db.or_fail ~cmd:"create sturdy_refs_rev";
+  let add = Sqlite3.prepare db "INSERT INTO sturdy_refs (hash, type, args, created) VALUES (?, ?, ?, date('now'))" in
+  let remove = Sqlite3.prepare db "DELETE FROM sturdy_refs WHERE hash = ?" in
+  let lookup_by_hash = Sqlite3.prepare db "SELECT type, args FROM sturdy_refs WHERE hash = ?" in
+  let lookup_by_descr = Sqlite3.prepare db "SELECT hash FROM sturdy_refs WHERE type = ? AND args = ?" in
+  let list_by_type = Sqlite3.prepare db "SELECT hash, args FROM sturdy_refs WHERE type = ? ORDER BY args" in
+  let load ~validate ~sturdy_ref descr = load ~validate ~sturdy_ref:(Sturdy_ref.cast sturdy_ref) descr in
+  { db; make_sturdy; load; add; remove; lookup_by_hash; lookup_by_descr; list_by_type }
+
+let lookup_by_hash t hash =
+  match Db.query_some t.lookup_by_hash Sqlite3.Data.[ BLOB hash ] with
+  | Some Sqlite3.Data.[TEXT ty; BLOB args] -> Some (Ty.of_string ty, args)
+  | Some row -> Fmt.failwith "lookup_by_hash: bad row: %a" Db.dump_row row
+  | None -> None
+
+let lookup_by_descr t (ty, args) =
+  let ty = Ty.to_string ty in
+  Db.query t.lookup_by_descr Sqlite3.Data.[ TEXT ty; BLOB args ] |> List.map @@ function
+  | Sqlite3.Data.[BLOB hash] -> hash
+  | row -> Fmt.failwith "lookup_by_args: bad row: %a" Db.dump_row row
+
+let list_by_type t ty =
+  let ty = Ty.to_string ty in
+  Db.query t.list_by_type Sqlite3.Data.[ TEXT ty ]
+  |> List.map @@ function
+  | Sqlite3.Data.[BLOB hash; BLOB args] -> hash, args
+  | row -> Fmt.failwith "list_by_type: bad row: %a" Db.dump_row row
+
+let hash _ = `SHA256
+
+let add t (ty, args) =
+  let ty = Ty.to_string ty in
+  let secret = Secret.generate () in
+  let digest = Secret.digest (hash t) secret in
+  Db.exec t.add Sqlite3.Data.[ BLOB digest; TEXT ty; BLOB args ];
+  secret
+
+let remove t digest =
+  Db.exec t.remove Sqlite3.Data.[ BLOB digest ];
+  if Sqlite3.changes t.db = 0 then raise Not_found
+
+let validate t digest () =
+  match lookup_by_hash t digest with
+  | None -> false
+  | Some _ -> true
+
+let load t self digest =
+  match lookup_by_hash t digest with
+  | None -> Lwt.return Capnp_rpc_net.Restorer.unknown_service_id
+  | Some descr -> t.load ~validate:(validate t digest) ~sturdy_ref:(Capnp_rpc_lwt.Sturdy_ref.cast self) descr
+
+let make_sturdy t = t.make_sturdy

--- a/scheduler/sqlite_loader.mli
+++ b/scheduler/sqlite_loader.mli
@@ -1,0 +1,56 @@
+include Capnp_rpc_net.Restorer.LOADER
+
+module Ty : sig
+  (** The database can store different types of resource.
+      It uses strings to identify them, but the rest of the code uses OCaml types.
+      This module maintains a mapping between type names and OCaml types. *)
+
+  type t = ..
+
+  val register : string -> t -> unit
+  (** [register_type name ty] registers [name] as the string representation of [ty].
+      A single database may be used to store resources from several libraries, so try to pick
+      a unique type name. *)
+
+  val pp : t Fmt.t
+end
+
+type descr = (Ty.t * string)
+(** A [descr] contains the information stored in the database which is used to restore a capability.
+    This string are the "arguments", passed to the user's [load] function. *)
+
+type digest = private string
+
+val create :
+  make_sturdy:(Capnp_rpc_net.Restorer.Id.t -> Uri.t) ->
+  load:(validate:(unit -> bool) ->
+        sturdy_ref:'a Capnp_rpc_lwt.Sturdy_ref.t ->
+        descr ->
+        Capnp_rpc_net.Restorer.resolution Lwt.t
+       ) ->
+  Db.t ->
+  t
+(** [create ~make_sturdy ~load db] is a loader that persists information about sturdy refs in an sqlite3 database.
+    [make_sturdy] converts a secret ID to a sturdy URI.
+    Use e.g. {!Capnp_rpc_unix.Vat_config.sturdy_uri} for this.
+    When a request for a previously-issued sturdy ref arrives,
+    the loader gets the type and arguments for the object from the database
+    and then calls [load ~validate ~sturdy_ref descr] to create the live ref.
+    [sturdy_ref] is the object's own sturdy-ref, which it may want to hand back to clients
+    (e.g. if implementing the persistence API).
+    [validate] can be used to check whether the object is still in the table, to handle revocation.
+*)
+
+val add : t -> descr -> Capnp_rpc_net.Restorer.Id.t
+(** [add t descr] generates and returns new secret ID. It also adds [descr] to the database under the hash of this secret.
+    If a user later uses the secret to connect, [descr] will be used to load the object. *)
+
+val remove : t -> digest -> unit
+(** [remove t hash] removes the entry with the given hash, if any.
+    @raise Not_found if [digest] is not present. *)
+
+val list_by_type : t -> Ty.t -> (digest * string) list
+(** [list_by_type t ty] returns all entries [(digest, args)] with the given [ty]. *)
+
+val lookup_by_descr : t -> descr -> digest list
+(** [lookup_by_descr t descr] returns all entries with the given type and arguments. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,6 +1,8 @@
 open Capnp_rpc_lwt
 open Lwt.Infix
 
+module Restorer = Capnp_rpc_net.Restorer
+
 (* Setting this to true shows log output, which is useful if the tests hang.
    However, it also hides the Alcotest diff if it fails. *)
 let verbose = false
@@ -54,19 +56,29 @@ let with_sched fn =
   Lwt.finalize
     (fun () ->
        let sched = Cluster_scheduler.create ~db ["pool"] in
+       let load ~validate ~sturdy_ref = function
+         | Cluster_scheduler.Client, name ->
+           Lwt.return @@ Restorer.grant (Cluster_scheduler.submission_service ~validate ~sturdy_ref sched name)
+         | (ty, _) -> Fmt.failwith "Unknown SturdyRef type %a found in database!" Cluster_scheduler.Sqlite_loader.Ty.pp ty
+       in
+       let make_sturdy _ = Uri.of_string "mock:sturdy" in
+       let loader = Cluster_scheduler.Sqlite_loader.create ~make_sturdy ~load db in
+       let services = Restorer.Table.of_loader (module Cluster_scheduler.Sqlite_loader) loader in
+       let restore = Restorer.of_table services in
        let pools = Cluster_scheduler.registration_services sched in
        match pools with
        | ["pool", registration_service] ->
          Capability.with_ref registration_service @@ fun registry ->
-         Capability.with_ref (Cluster_scheduler.submission_service sched) @@ fun submission_service ->
-         fn ~submission_service ~registry
+         Capability.with_ref (Cluster_scheduler.admin_service sched ~restore ~loader) @@ fun admin ->
+         fn ~admin ~registry
        | _ -> failwith "Missing pool!"
     )
     (fun () -> if Sqlite3.db_close db then Lwt.return_unit else failwith "close: DB busy!")
 
 (* Build on a single worker. *)
 let simple () =
-  with_sched @@ fun ~submission_service ~registry ->
+  with_sched @@ fun ~admin ~registry ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   let builder = Mock_builder.create () in
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder (Mock_network.sturdy registry);
@@ -80,7 +92,8 @@ let simple () =
 (* A failing build on a single worker. *)
 let fails () =
   let builder = Mock_builder.create () in
-  with_sched @@ fun ~submission_service ~registry ->
+  with_sched @@ fun ~admin ~registry ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder (Mock_network.sturdy registry);
   let result = submit submission_service "example2" in
@@ -93,7 +106,8 @@ let fails () =
 (* The job is submitted before any builders are registered. *)
 let await_builder () =
   let builder = Mock_builder.create () in
-  with_sched @@ fun ~submission_service ~registry ->
+  with_sched @@ fun ~admin ~registry ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   let result = submit submission_service "example" in
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder (Mock_network.sturdy registry);
@@ -106,7 +120,8 @@ let await_builder () =
 (* A single builder can't do all the jobs and they queue up. *)
 let builder_capacity () =
   let builder = Mock_builder.create () in
-  with_sched @@ fun ~submission_service ~registry ->
+  with_sched @@ fun ~admin ~registry ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder (Mock_network.sturdy registry) ~capacity:2;
   let r1 = submit submission_service "example1" in
@@ -125,9 +140,7 @@ let builder_capacity () =
   Lwt.return_unit
 
 let admin () =
-  let db = Sqlite3.db_open ":memory:" in
-  let sched = Cluster_scheduler.create ~db ["pool"] in
-  Capability.with_ref (Cluster_scheduler.admin_service sched) @@ fun admin ->
+  with_sched @@ fun ~admin ~registry:_ ->
   Cluster_api.Admin.pools admin >>= fun pools ->
   Alcotest.(check (list string)) "Check pools" ["pool"] pools;
   Capability.with_ref (Cluster_api.Admin.pool admin "pool") @@ fun pool ->
@@ -139,7 +152,8 @@ let admin () =
 let network () =
   Lwt_switch.with_switch (fun network_switch ->
       let builder = Mock_builder.create () in
-      with_sched @@ fun ~submission_service ~registry ->
+      with_sched @@ fun ~admin ~registry ->
+      Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
       Lwt_switch.with_switch @@ fun builder_switch ->
       Mock_builder.run_remote builder ~network_switch ~builder_switch registry;
       let result = submit submission_service "example" in
@@ -156,7 +170,8 @@ let worker_disconnects () =
   let network_switch = Lwt_switch.create () in
   Lwt_switch.with_switch @@ fun builder_switch ->
   let builder = Mock_builder.create () in
-  with_sched @@ fun ~submission_service ~registry ->
+  with_sched @@ fun ~admin ~registry ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   Mock_builder.run_remote builder ~builder_switch ~network_switch registry;
   (* Run a job to ensure it's connected. *)
   let result = submit submission_service "example" in
@@ -180,7 +195,8 @@ let worker_disconnects () =
 (* The client gets disconnected. The job is automatically cancelled. *)
 let client_disconnects () =
   let builder = Mock_builder.create () in
-  with_sched @@ fun ~submission_service ~registry ->
+  with_sched @@ fun ~admin ~registry ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   Lwt_switch.with_switch @@ fun builder_switch ->
   let net_switch = Lwt_switch.create () in
   Sturdy_ref.connect_exn (Mock_network.remote ~switch:net_switch submission_service) >>= fun submission_service ->
@@ -201,7 +217,8 @@ let client_disconnects () =
 
 (* The client cancels the job explicitly. *)
 let cancel () =
-  with_sched @@ fun ~submission_service ~registry ->
+  with_sched @@ fun ~admin ~registry ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   let builder = Mock_builder.create () in
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder (Mock_network.sturdy registry);
@@ -221,7 +238,8 @@ let cancel () =
 
 (* The client cancels the ticket. *)
 let cancel_ticket () =
-  with_sched @@ fun ~submission_service ~registry:_ ->
+  with_sched @@ fun ~admin ~registry:_ ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   let action = Cluster_api.Submission.docker_build (`Contents "example") in
   Capability.with_ref (Cluster_api.Submission.submit submission_service ~pool:"pool" ~action ~cache_hint:"1" ?src:None) @@ fun ticket ->
   Capability.with_ref (Cluster_api.Ticket.job ticket) @@ fun job ->
@@ -238,7 +256,8 @@ let cancel_ticket () =
 
 (* The client cancels the ticket after the job is assigned. *)
 let cancel_ticket_late () =
-  with_sched @@ fun ~submission_service ~registry ->
+  with_sched @@ fun ~admin ~registry ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   let builder = Mock_builder.create () in
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder (Mock_network.sturdy registry);
@@ -259,7 +278,8 @@ let cancel_ticket_late () =
 
 (* The client releases the ticket before the job is assigned. *)
 let release_ticket () =
-  with_sched @@ fun ~submission_service ~registry:_ ->
+  with_sched @@ fun ~admin ~registry:_ ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   let action = Cluster_api.Submission.docker_build (`Contents "example") in
   let ticket = Cluster_api.Submission.submit submission_service ~pool:"pool" ~action ~cache_hint:"1" ?src:None in
   let job = Cluster_api.Ticket.job ticket in
@@ -276,7 +296,8 @@ let release_ticket () =
 
 (* The client releases the ticket after the job is assigned. *)
 let release_ticket_late () =
-  with_sched @@ fun ~submission_service ~registry ->
+  with_sched @@ fun ~admin ~registry ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client") @@ fun submission_service ->
   let builder = Mock_builder.create () in
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder (Mock_network.sturdy registry);
@@ -295,6 +316,36 @@ let release_ticket_late () =
   let result = Result.map_error (fun (`Capnp e) -> Fmt.to_to_string Capnp_rpc.Error.pp e) result in
   Alcotest.(check (result string string)) "Check job cancelled" (Error "Failed: Build cancelled") result;
   Lwt.return_unit
+
+(* Registering and removing clients. *)
+let clients () =
+  with_sched @@ fun ~admin ~registry:_ ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client1") @@ fun client1 ->
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client2") @@ fun client2 ->
+  Cluster_api.Admin.list_clients admin >>= fun clients ->
+  Alcotest.(check (list string)) "2 clients" ["client1"; "client2"] clients;
+  Cluster_api.Admin.remove_client admin "client1" >>= fun () ->
+  Cluster_api.Admin.list_clients admin >>= fun clients ->
+  Alcotest.(check (list string)) "2 clients" ["client2"] clients;
+  let action = Cluster_api.Submission.docker_build (`Contents "example") in
+  let ticket1 = Cluster_api.Submission.submit client1 ~pool:"pool" ~action ~cache_hint:"1" in
+  let ticket2 = Cluster_api.Submission.submit client2 ~pool:"pool" ~action ~cache_hint:"1" in
+  Capability.wait_until_settled ticket1 >>= fun () ->
+  Capability.wait_until_settled ticket2 >>= fun () ->
+  let pp_err = Fmt.(option ~none:(unit "ok")) Capnp_rpc.Exception.pp in
+  let problem1 = Fmt.strf "%a" pp_err (Capability.problem ticket1) in
+  Alcotest.(check string) "Access revoked" "Failed: Access has been revoked" problem1;
+  let problem2 = Fmt.strf "%a" pp_err (Capability.problem ticket2) in
+  Alcotest.(check string) "Access OK" "ok" problem2;
+  Capability.dec_ref ticket2;
+  Capability.with_ref (Cluster_api.Admin.add_client admin "client2") @@ fun client2b ->
+  Capability.wait_until_settled client2b >>= fun () ->
+  let problem = Fmt.strf "%a" pp_err (Capability.problem client2b) in
+  Alcotest.(check string) "Duplicate user" {|Failed: Client "client2" already registered!|} problem;
+  Lwt.try_bind
+    (fun () -> Cluster_api.Admin.remove_client admin "client1")
+    (fun () -> Alcotest.fail "Should have failed!")
+    (fun _ -> Lwt.return_unit)
 
 let test_case name fn =
   Alcotest_lwt.test_case name `Quick @@ fun _ () ->
@@ -322,6 +373,7 @@ let () =
       test_case "release_ticket" release_ticket;
       test_case "release_ticket_late" release_ticket_late;
       test_case "admin" admin;
+      test_case "clients" clients;
     ];
     "scheduling", Test_scheduling.suite;
     "plugin", Test_plugin.suite;


### PR DESCRIPTION
Instead of creating a single `submission.cap` at start-up, use `ocluster-admin add-client` to create a submission endpoint for each client.

This is to make it possible to take scheduling decisions based on the client in future, e.g. to avoid one client starving all the others.