### PR TITLE
Workers report capacity when registering

### DIFF
--- a/api/registration.ml
+++ b/api/registration.ml
@@ -8,13 +8,18 @@ let local ~register =
     method register_impl params release_param_caps =
       let open X.Register in
       let name = Params.name_get params in
+      let capacity =
+        let x = Params.capacity_get_int_exn params in
+        if x > 0 then x
+        else 32   (* Old workers don't report their capacity. *)
+      in
       let worker = Params.worker_get params in
       release_param_caps ();
       match worker with
       | None -> Service.fail "Missing worker argument!"
       | Some worker ->
         let response, results = Service.Response.create Results.init_pointer in
-        let queue = register ~name worker in
+        let queue = register ~name ~capacity worker in
         Results.queue_set results (Some queue);
         Capability.dec_ref queue;
         Service.return response
@@ -24,9 +29,10 @@ module X = Raw.Client.Registration
 
 type t = X.t Capability.t
 
-let register t ~name worker =
+let register t ~name ~capacity worker =
   let open X.Register in
   let request, params = Capability.Request.create Params.init_pointer in
   Params.name_set params name;
   Params.worker_set params (Some worker);
+  Params.capacity_set_int_exn params capacity;
   Capability.call_for_caps t method_id request Results.queue_get_pipelined

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -104,7 +104,13 @@ interface Worker {
 }
 
 interface Registration {
-  register @0 (name :Text, worker :Worker) -> (queue :Queue);
+  register @0 (name :Text, worker :Worker, capacity: Int32) -> (queue :Queue);
+  # Workers call this at startup to register themselves with the scheduler.
+  # The scheduler replies with a queue, from which the worker can pull jobs.
+  # The "worker" object is used to collect metrics and perform admin.
+  # The "capacity" gives the number of jobs that the worker will perform in
+  # parallel. At present, this is only used to estimate the cluster's capacity;
+  # workers can pull as many jobs as they like from the queue.
 }
 
 interface Ticket {

--- a/scheduler/cluster_scheduler.ml
+++ b/scheduler/cluster_scheduler.ml
@@ -74,8 +74,8 @@ module Pool_api = struct
       Capability.resolve_ok set_job job;
       Ok descr
 
-  let register t ~name worker =
-    match Pool.register t.pool ~name with
+  let register t ~name ~capacity worker =
+    match Pool.register t.pool ~name ~capacity with
     | Error `Name_taken ->
       Fmt.failwith "Worker already registered!";
     | Ok q ->

--- a/scheduler/pool.mli
+++ b/scheduler/pool.mli
@@ -19,8 +19,9 @@ module Make (Item : S.ITEM) : sig
   (** [create ~name ~db] is a pool that reports metrics tagged with [name] and
       stores cache information in [db]. *)
 
-  val register : t -> name:string -> (worker, [> `Name_taken]) result
-  (** [register t ~name] returns a queue for worker [name]. *)
+  val register : t -> name:string -> capacity:int -> (worker, [> `Name_taken]) result
+  (** [register t ~name ~capacity] returns a queue for worker [name].
+      @param capacity Worker's capacity (max number of parallel jobs). *)
 
   val submit : urgent:bool -> t -> Item.t -> ticket
   (** [submit ~urgent t item] adds [item] to the incoming queue.

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -420,7 +420,7 @@ let run ?switch ?build ?(allow_push=[]) ?prune_threshold ?obuilder ~update ~capa
          Capability.with_ref reg @@ fun reg ->
          let queue =
            let api = Cluster_api.Worker.local ~metrics ~self_update:(fun () -> self_update ~update t) in
-           let queue = Cluster_api.Registration.register reg ~name api in
+           let queue = Cluster_api.Registration.register reg ~name ~capacity api in
            Capability.dec_ref api;
            queue
          in


### PR DESCRIPTION
This is useful information about the cluster, and may also be useful for fair scheduling to decide how long we expect some work to take. It may also be useful if we want to reserve some capacity for urgent work.