### PR TITLE
Fair queuing

### DIFF
--- a/api/registration.ml
+++ b/api/registration.ml
@@ -8,11 +8,7 @@ let local ~register =
     method register_impl params release_param_caps =
       let open X.Register in
       let name = Params.name_get params in
-      let capacity =
-        let x = Params.capacity_get_int_exn params in
-        if x > 0 then x
-        else 32   (* Old workers don't report their capacity. *)
-      in
+      let capacity = Params.capacity_get_int_exn params in
       let worker = Params.worker_get params in
       release_param_caps ();
       match worker with

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -139,6 +139,9 @@ interface PoolAdmin {
 
   update    @4 (worker :Text) -> ();
   # Drain worker, ask it to restart with the latest version, and return when it comes back.
+
+  setRate   @5 (id :Text, rate :Float64) -> ();
+  # Set the expected share of the pool for this client.
 }
 
 interface Admin {

--- a/dune-project
+++ b/dune-project
@@ -37,6 +37,7 @@
   cohttp-lwt-unix
   sqlite3
   obuilder
+  psq
   (mirage-crypto (>= 0.8.5))
   (ocaml (>= 4.10.0))
   (current_ocluster (and (= :version) :with-test))

--- a/ocluster.opam
+++ b/ocluster.opam
@@ -21,6 +21,7 @@ depends: [
   "cohttp-lwt-unix"
   "sqlite3"
   "obuilder"
+  "psq"
   "mirage-crypto" {>= "0.8.5"}
   "ocaml" {>= "4.10.0"}
   "current_ocluster" {= version & with-test}

--- a/scheduler/cluster_scheduler.ml
+++ b/scheduler/cluster_scheduler.ml
@@ -34,38 +34,25 @@ end
 module Pool_api = struct
   module Pool = Pool.Make(Item)(Unix)
 
-  module Client_map = Map.Make(String)
-
   type t = {
     pool : Pool.t;
-    mutable clients : Pool.Client.t Client_map.t;
     workers : (string, Cluster_api.Worker.t) Hashtbl.t;
     cond : unit Lwt_condition.t;    (* Fires when a worker joins *)
   }
 
   let create ~name ~db =
     let pool = Pool.create ~name ~db in
-    let clients = Client_map.empty in
     let workers = Hashtbl.create 10 in
     let cond = Lwt_condition.create () in
-    { pool; clients; workers; cond }
+    { pool; workers; cond }
 
-  let client t ~client_id =
-    match Client_map.find_opt client_id t.clients with
-    | Some c -> c
-    | None ->
-      let client = Pool.client t.pool ~client_id in
-      t.clients <- Client_map.add client_id client t.clients;
-      client
-
-  let submit t ~urgent ~client_id (descr : Cluster_api.Queue.job_desc) : Cluster_api.Ticket.t =
-    let client = client t ~client_id in
+  let submit client ~urgent ~client_id (descr : Cluster_api.Queue.job_desc) : Cluster_api.Ticket.t =
     let job, set_job = Capability.promise () in
     Log.info (fun f -> f "Received new job request from %S (urgent=%b)" client_id urgent);
     let item = { Item.descr; set_job } in
-    let ticket = Pool.submit ~urgent client item in
+    let ticket = Pool.Client.submit ~urgent client item in
     let cancel () =
-      match Pool.cancel ticket with
+      match Pool.Client.cancel client ticket with
       | Ok () ->
         Capability.resolve_exn set_job (Capnp_rpc.Exception.v "Ticket cancelled");
         Lwt_result.return ()
@@ -73,7 +60,7 @@ module Pool_api = struct
         Cluster_api.Job.cancel job
     in
     let release () =
-      match Pool.cancel ticket with
+      match Pool.Client.cancel client ticket with
       | Ok () -> Capability.resolve_exn set_job (Capnp_rpc.Exception.v "Ticket released (cancelled)")
       | Error `Not_queued -> ()
     in
@@ -116,7 +103,7 @@ module Pool_api = struct
       Capability.inc_ref w;
       Some w
 
-  let admin_service t =
+  let admin_service ~validate_client t =
     let show () = Fmt.to_to_string Pool.show t.pool in
     let workers () =
       Pool.connected_workers t.pool
@@ -155,7 +142,17 @@ module Pool_api = struct
           in
           Lwt.pick [ aux (); timeout ]
     in
-    Cluster_api.Pool_admin.local ~show ~workers ~worker:(worker t) ~set_active ~update
+    let set_rate ~client_id rate =
+      if validate_client client_id then (
+        let client = Pool.client t.pool ~client_id in
+        Pool.Client.set_rate client rate;
+        Ok ()
+      ) else Error `No_such_user
+    in
+    Cluster_api.Pool_admin.local ~show ~workers ~worker:(worker t) ~set_active ~update ~set_rate
+
+  let remove_client t ~client_id =
+    Pool.remove_client t.pool ~client_id
 end
 
 type t = {
@@ -168,16 +165,27 @@ let registration_services t =
 let pp_pool_name f (name, _) = Fmt.string f name
 
 let submission_service ~validate ~sturdy_ref t client_id =
+  let pools = Hashtbl.create 3 in
+  let get_client pool_id =
+    match Hashtbl.find_opt pools pool_id with
+    | Some c -> Ok c
+    | None ->
+      match String.Map.find_opt pool_id t.pools with
+      | None ->
+        let msg = Fmt.strf "Pool ID %S not one of @[<h>{%a}@]" pool_id (String.Map.pp ~sep:Fmt.comma pp_pool_name) t.pools in
+        Error (Capnp_rpc.Exception.v msg)
+      | Some pool ->
+        let client = Pool_api.Pool.client pool.pool ~client_id in
+        Hashtbl.add pools pool_id client;
+        Ok client
+  in
   let submit ~pool ~urgent descr =
     match validate () with
     | false -> Capability.broken (Capnp_rpc.Exception.v "Access has been revoked")
     | true ->
-      match String.Map.find_opt pool t.pools with
-      | None ->
-        let msg = Fmt.strf "Pool ID %S not one of @[<h>{%a}@]" pool (String.Map.pp ~sep:Fmt.comma pp_pool_name) t.pools in
-        Capability.broken (Capnp_rpc.Exception.v msg)
-      | Some pool ->
-        Pool_api.submit ~urgent ~client_id pool descr
+      match get_client pool with
+      | Ok client -> Pool_api.submit ~urgent ~client_id client descr
+      | Error ex -> Capability.broken ex
   in
   Cluster_api.Submission.local ~submit ~sturdy_ref
 
@@ -189,7 +197,13 @@ let admin_service ~loader ~restore t =
   let pool name =
     match String.Map.find_opt name t.pools with
     | None -> Capability.broken (Capnp_rpc.Exception.v "No such pool")
-    | Some pool_api -> Pool_api.admin_service pool_api
+    | Some pool_api ->
+      let validate_client id =
+        match Sqlite_loader.lookup_by_descr loader (Client, id) with
+        | [] -> false
+        | _ -> true
+      in
+      Pool_api.admin_service ~validate_client pool_api
   in
   let add_client name =
     let descr = (Client, name) in
@@ -206,6 +220,7 @@ let admin_service ~loader ~restore t =
     match Sqlite_loader.lookup_by_descr loader descr with
     | [digest] ->
       Sqlite_loader.remove loader digest;
+      t.pools |> String.Map.iter (fun _ -> Pool_api.remove_client ~client_id:name);
       Log.info (fun f -> f "Removed endpoint for client %S" name);
       Lwt_result.return ()
     | [] -> Lwt_result.fail (`Capnp (Capnp_rpc.Error.exn "Unknown client %S" name))

--- a/scheduler/dune
+++ b/scheduler/dune
@@ -1,3 +1,3 @@
 (library
  (name cluster_scheduler)
- (libraries ocluster-api logs capnp-rpc-lwt capnp-rpc-net lwt-dllist prometheus db lwt.unix))
+ (libraries ocluster-api logs capnp-rpc-lwt capnp-rpc-net lwt-dllist prometheus db lwt.unix psq))

--- a/scheduler/pool.ml
+++ b/scheduler/pool.ml
@@ -35,13 +35,21 @@ module Metrics = struct
   let workers_paused =
     let help = "Number of workers set to inactive" in
     Gauge.v_label ~label_name:"pool" ~help ~namespace ~subsystem "workers_paused"
+
+  let priority ~urgent =
+    if urgent then "high" else "low"
 end
+
+module Client_map = Map.Make(String)
 
 module Dao = struct
   type t = {
     query_cache : Sqlite3.stmt;
     mark_cached : Sqlite3.stmt;
     dump_cache : Sqlite3.stmt;
+    get_rate : Sqlite3.stmt;
+    set_rate : Sqlite3.stmt;
+    remove_user : Sqlite3.stmt;
   }
 
   let dump f (db, pool) =
@@ -69,6 +77,14 @@ module Dao = struct
   let mark_cached t ~pool ~hint ~worker =
     Db.exec t.mark_cached Sqlite3.Data.[ TEXT pool; TEXT hint; TEXT worker ]
 
+  let get_rate t ~pool ~client_id =
+    Db.query_some t.get_rate Sqlite3.Data.[ TEXT pool; TEXT client_id ]
+    |> Option.map (function
+        | Sqlite3.Data.[ FLOAT rate ] -> rate
+        | row -> Fmt.failwith "Bad row from DB: %a" Db.dump_row row
+      )
+    |> Option.value ~default:1.0
+
   let init db =
     Sqlite3.exec db "CREATE TABLE IF NOT EXISTS cached ( \
                      pool       TEXT NOT NULL, \
@@ -76,15 +92,29 @@ module Dao = struct
                      worker     TEXT NOT NULL, \
                      created    DATETIME NOT NULL, \
                      PRIMARY KEY (pool, cache_hint, worker))" |> Db.or_fail ~cmd:"create table";
+    Sqlite3.exec db "CREATE TABLE IF NOT EXISTS pool_user_rate ( \
+                     pool       TEXT NOT NULL, \
+                     user       TEXT NOT NULL, \
+                     rate       REAL NOT NULL, \
+                     PRIMARY KEY (pool, user))" |> Db.or_fail ~cmd:"create pool_user_rate table";
     let query_cache = Sqlite3.prepare db "SELECT worker FROM cached WHERE pool = ? AND cache_hint = ? ORDER BY worker" in
     let mark_cached = Sqlite3.prepare db "INSERT OR REPLACE INTO cached (pool, cache_hint, worker, created) VALUES (?, ?, ?, date('now'))" in
     let dump_cache = Sqlite3.prepare db "SELECT DISTINCT cache_hint FROM cached WHERE pool = ? ORDER BY cache_hint" in
-    { query_cache; mark_cached; dump_cache }
+    let set_rate = Sqlite3.prepare db "INSERT OR REPLACE INTO pool_user_rate (pool, user, rate) VALUES (?, ?, ?)" in
+    let get_rate = Sqlite3.prepare db "SELECT rate FROM pool_user_rate WHERE pool = ? AND user = ?" in
+    let remove_user = Sqlite3.prepare db "DELETE FROM pool_user_rate WHERE pool = ? AND user = ?" in
+    { query_cache; mark_cached; dump_cache; set_rate; get_rate; remove_user }
 end
 
 let (let<>) x f =
   if x = 0 then f ()
   else x
+
+let pp_rough_duration f x =
+  if x < 120.0 then
+    Fmt.pf f "%.0fs" x
+  else
+    Fmt.pf f "%.0fm" (x /. 60.)
 
 module Make (Item : S.ITEM)(Time : S.TIME) = struct
   module Worker_map = Astring.String.Map
@@ -94,6 +124,7 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
     item : Item.t;
     fair_start_time : float;
     urgent : bool;
+    client_id : string;
     mutable cost : int;                         (* Estimated cost (set when added to worker queue) *)
     mutable cancel : (unit -> unit) option;     (* None if not in a queue *)
   }
@@ -107,15 +138,6 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
   let clear_cancel ticket =
     assert (ticket.cancel <> None);
     ticket.cancel <- None
-
-  let cancel ticket =
-    match ticket.cancel with
-    | None -> Error `Not_queued
-    | Some fn ->
-      Log.info (fun f -> f "Cancel %a" pp_ticket ticket);
-      ticket.cancel <- None;
-      fn ();
-      Ok ()
 
   module Backlog = struct
     module Key = struct
@@ -131,12 +153,18 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
         let<> () = compare b.urgent a.urgent in
         compare a.fair_start_time b.fair_start_time
 
-      let pp f ticket =
+      let pp_ticket ~now f ticket =
+        Fmt.pf f "%s:%a@@%a"
+          ticket.client_id
+          Item.pp ticket.item
+          pp_rough_duration (ticket.fair_start_time -. now)
+
+      let pp ~now f ticket =
         let urgent = if ticket.urgent then "+urgent" else "" in
         if ticket.cost >= 0 then
-          Fmt.pf f "%a(%d%s)" pp_ticket ticket ticket.cost urgent
+          Fmt.pf f "%a(%d%s)" (pp_ticket ~now) ticket ticket.cost urgent
         else
-          Fmt.pf f "%a%s" pp_ticket ticket urgent
+          Fmt.pf f "%a%s" (pp_ticket ~now) ticket urgent
     end
 
     module Q = Psq.Make(Key)(Ticket)
@@ -146,14 +174,6 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
       mutable psq : Q.t;
     }
 
-    let choose_queue ~ticket ~pool t =
-      let priority =
-        match ticket.urgent with
-        | true -> "high"
-        | false -> "low"
-      in
-      Prometheus.Gauge.labels Metrics.queue_length [t.queue; pool; priority]
-
     let cancel t ?(on_cancel=ignore) ~metric ~pool key () =
       t.psq <- Q.remove key t.psq;
       Prometheus.Counter.inc_one (Metrics.jobs_cancelled pool);
@@ -161,7 +181,7 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
       on_cancel ()
 
     let enqueue ?on_cancel ~pool ticket t =
-      let metric = choose_queue ~ticket ~pool t in
+      let metric = Prometheus.Gauge.labels Metrics.queue_length [t.queue; pool; Metrics.priority ~urgent:ticket.urgent] in
       t.psq <- Q.add ticket.key ticket t.psq;
       set_cancel ticket (cancel t ?on_cancel ~metric ~pool ticket.key);
       Prometheus.Gauge.inc_one metric
@@ -183,8 +203,9 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
 
     let dump f t =
       let items = Q.to_priority_list t.psq |> List.rev in
-      Fmt.pf f "[%a]"
-        (Fmt.(list ~sep:sp) (Fmt.using snd Ticket.pp)) items
+      let now = Time.gettimeofday () in
+      Fmt.pf f "[@[<hov>%a@]]"
+        (Fmt.(list ~sep:sp) (Fmt.using snd (Ticket.pp ~now))) items
 
     let create ~queue () =
       {
@@ -201,7 +222,9 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
       | `Ready of worker Lwt_dllist.t       (* No work is available. *)
     ];
     mutable workers : worker Worker_map.t;  (* Connected workers *)
+    mutable clients : client_info Client_map.t;
     mutable cluster_capacity : float;
+    mutable pending_cached : (Item.cache_hint, int) Hashtbl.t;
   } and worker = {
     parent : t;
     name : string;
@@ -211,25 +234,11 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
                     | `Finished ];
     mutable workload : int;     (* Total cost of items in worker's queue. *)
     mutable shutdown : bool;    (* Worker is paused because it is shutting down. *)
+  } and client_info = {
+    id : string;
+    mutable next_fair_start_time : float;
+    mutable finished : bool;
   }
-
-  module Client = struct
-    type nonrec t = {
-      parent : t;
-      id : string;
-      mutable next_fair_start_time : float;
-    }
-
-    let v ~parent ~id = { parent; id; next_fair_start_time = Unix.gettimeofday () }
-
-    let schedule t cost =
-      let start = max (Time.gettimeofday ()) t.next_fair_start_time in
-      t.next_fair_start_time <- start +. cost;
-      start
-  end
-
-  let client t ~client_id =
-    Client.v ~parent:t ~id:client_id
 
   let enqueue_node item queue metric =
     let node = Lwt_dllist.add_l item queue in
@@ -248,6 +257,16 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
     let ticket = Backlog.dequeue_opt ~pool queue in
     Option.iter (fun ticket -> worker.workload <- worker.workload - ticket.cost) ticket;
     ticket
+
+  let dec_pending_count t ticket =
+    let hint = Item.cache_hint ticket.item in
+    if (hint :> string) <> "" then (
+      let pending_count = Hashtbl.find t.pending_cached hint in
+      if pending_count > 1 then
+        Hashtbl.replace t.pending_cached hint (pending_count - 1)
+      else
+        Hashtbl.remove t.pending_cached hint
+    )
 
   (* Return the worker in [workers] with the lowest workload. *)
   let best_worker ~max_workload t workers =
@@ -309,6 +328,7 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
           Log.info (fun f -> f "%S takes %a from its local queue" worker.name Item.pp item);
           mark_cached ticket.item worker;
           Prometheus.Counter.inc_one (Metrics.jobs_accepted t.pool);
+          dec_pending_count t ticket;
           Lwt_result.return ticket.item
         | None ->
           (* Try the global queue instead. *)
@@ -335,6 +355,7 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
                 Log.info (fun f -> f "%S takes %a from the main queue" worker.name Item.pp item);
                 mark_cached item worker;
                 Prometheus.Counter.inc_one (Metrics.jobs_accepted t.pool);
+                dec_pending_count t ticket;
                 Lwt_result.return item
               )
     in
@@ -397,15 +418,6 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
           mark_cached ticket.item worker;
           Lwt_condition.broadcast cond ()
       )
-
-  let submit ~urgent client item =
-    let fair_start_time = Client.schedule client (float (Item.cost_estimate item).non_cached) in
-    let t = client.parent in
-    Prometheus.Counter.inc_one (Metrics.jobs_submitted t.pool);
-    let key = object end in
-    let ticket = { key; item; fair_start_time; urgent; cancel = None; cost = -1 } in
-    add t ticket;
-    ticket
 
   let add_items t worker_q worker =
     let rec aux () =
@@ -487,8 +499,10 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
       pool = name;
       db;
       main = `Backlog (Backlog.create ~queue:Metrics.incoming_queue ());
+      clients = Client_map.empty;
       workers = Worker_map.empty;
       cluster_capacity = 0.0;
+      pending_cached = Hashtbl.create 1024;
     }
 
   let dump_queue ?(sep=Fmt.sp) pp f q =
@@ -521,16 +535,111 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
     | `Ready q ->
       Fmt.pf f "(ready) %a" (dump_queue pp_worker) q
 
-  let show f {pool = _; db = _; main; workers; cluster_capacity } =
-    Fmt.pf f "@[<v>capacity: %.0f@,queue: @[%a@]@,@[<v2>registered:%a@]@]@."
-      cluster_capacity
-      dump_main main
-      dump_workers workers
+  let dump_client t ~now f (_, { id; next_fair_start_time; finished }) =
+    let delay = next_fair_start_time -. now in
+    if finished then Fmt.pf f "%s:FINISHED" id
+    else (
+      let rate = Dao.get_rate ~pool:t.pool ~client_id:id t.db in
+      let pp_delay f x =
+        if delay > 0.0 then Fmt.pf f "+%a" pp_rough_duration x
+      in
+      Fmt.pf f "%s(%.0f)%a" id rate pp_delay delay
+    )
 
-  let dump f {pool; db; main; workers; cluster_capacity } =
-    Fmt.pf f "@[<v>capacity: %.0f@,queue: @[%a@]@,@[<v2>registered:%a@]@,cached: @[%a@]@]@."
+  let dump_clients t f clients =
+    let now = Time.gettimeofday () in
+    Fmt.(seq ~sep:sp (dump_client t ~now)) f (Client_map.to_seq clients)
+
+  let pp_common f ({pool = _; db = _; main; clients; workers; cluster_capacity; pending_cached = _} as t) =
+    Fmt.pf f "capacity: %.0f@,queue: @[%a@]@,@[<v2>registered:%a@]@,clients: @[<hov>%a@]"
       cluster_capacity
       dump_main main
       dump_workers workers
-      Dao.dump (db, pool)
+      (dump_clients t) clients
+
+  let show f t =
+    Fmt.pf f "@[<v>%a@]@." pp_common t
+
+  let dump f t =
+    Fmt.pf f "@[<v>%a@,cached: @[%a@]@]@."
+      pp_common t
+      Dao.dump (t.db, t.pool)
+
+  module Client = struct
+    type nonrec t = {
+      parent : t;
+      info : client_info;
+    }
+
+    let set_rate (t:t) rate =
+      let pool = t.parent in
+      assert (rate > 0.0);
+      Db.exec pool.db.set_rate Sqlite3.Data.[ TEXT pool.pool; TEXT t.info.id; FLOAT rate ]
+
+    let get_rate (t:t) =
+      let pool = t.parent in
+      Dao.get_rate ~pool:pool.pool ~client_id:t.info.id pool.db
+
+    let schedule t cost =
+      let rate = get_rate t in
+      let start = max (Time.gettimeofday ()) t.info.next_fair_start_time in
+      t.info.next_fair_start_time <- start +. (cost /. rate);
+      start
+
+    let submit ~urgent (t:t) item =
+      assert (not t.info.finished);
+      let pool = t.parent in
+      let cost =
+        let costs = Item.cost_estimate item in
+        let hint = Item.cache_hint item in
+        if (hint :> string) = "" then costs.non_cached
+        else (
+          let pending_count = Hashtbl.find_opt pool.pending_cached hint |> Option.value ~default:0 in
+          Hashtbl.replace pool.pending_cached hint (pending_count + 1);
+          if pending_count > 0 || Dao.query_cache pool.db ~pool:pool.pool ~hint:(hint :> string) <> [] then costs.cached
+          else costs.non_cached
+        )
+      in
+      let fair_start_time = schedule t (float cost) in
+      Prometheus.Counter.inc_one (Metrics.jobs_submitted pool.pool);
+      let key = object end in
+      let ticket = { key; item; client_id = t.info.id; fair_start_time; urgent; cancel = None; cost = -1 } in
+      add pool ticket;
+      ticket
+
+    let cancel (t:t) ticket =
+      assert (not t.info.finished);
+      match ticket.cancel with
+      | None -> Error `Not_queued
+      | Some fn ->
+        Log.info (fun f -> f "Cancel %a" pp_ticket ticket);
+        dec_pending_count t.parent ticket;
+        ticket.cancel <- None;
+        fn ();
+        Ok ()
+
+    let v parent info = { parent; info }
+  end
+
+  let client t ~client_id =
+    let info =
+      match Client_map.find_opt client_id t.clients with
+      | Some c -> c
+      | None ->
+        let info = {
+          id = client_id;
+          next_fair_start_time = Time.gettimeofday ();
+          finished = false;
+        } in
+        t.clients <- Client_map.add client_id info t.clients;
+        info
+    in
+    Client.v t info
+
+  let remove_client t ~client_id =
+    Db.exec t.db.remove_user Sqlite3.Data.[ TEXT t.pool; TEXT client_id ];
+    Client_map.find_opt client_id t.clients
+    |> Option.iter @@ fun client ->
+    client.finished <- true;
+    t.clients <- Client_map.remove client_id t.clients
 end

--- a/scheduler/pool.ml
+++ b/scheduler/pool.ml
@@ -618,6 +618,9 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
         fn ();
         Ok ()
 
+    let client_id t = t.info.id
+    let pool_id t = t.parent.pool
+
     let v parent info = { parent; info }
   end
 

--- a/scheduler/pool.mli
+++ b/scheduler/pool.mli
@@ -18,6 +18,22 @@ module Make (Item : S.ITEM) (Time : S.TIME) : sig
   module Client : sig
     type t
     (** A connected client. *)
+
+    val submit : urgent:bool -> t -> Item.t -> ticket
+    (** [submit ~urgent t item] adds [item] to the incoming queue.
+        [urgent] items will be processed before non-urgent ones. *)
+
+    val cancel : t -> ticket -> (unit, [> `Not_queued ]) result
+    (** [cancel t ticket] discards the item from the queue. *)
+
+    val set_rate : t -> float -> unit
+    (** [set_rate t rate] sets the maximum number of jobs that the client can expect
+        to run at once. Clients can submit more jobs than this, and make use of any
+        spare capacity. However, this will determine what happens when multiple clients
+        want to use the extra capacity. *)
+
+    val get_rate : t -> float
+    (** [get_rate t] is the rate previously set by [set_rate] (or [1.0] if never set). *)
   end
 
   val create : name:string -> db:Dao.t -> t
@@ -34,12 +50,9 @@ module Make (Item : S.ITEM) (Time : S.TIME) : sig
       one client does not starve the others.
       @param [client_id] Used for logging and reporting. *)
 
-  val submit : urgent:bool -> Client.t -> Item.t -> ticket
-  (** [submit ~urgent client item] adds [item] to the incoming queue.
-      [urgent] items will be processed before non-urgent ones. *)
-
-  val cancel : ticket -> (unit, [> `Not_queued ]) result
-  (** [cancel ticket] discards the item from the queue. *)
+  val remove_client : t -> client_id:string -> unit
+  (** [remove_client t ~client_id] deletes all information about [client_id], if any.
+      Call this on all pools when deleting a user. *)
 
   val pop : worker -> (Item.t, [> `Finished]) Lwt_result.t
   (** [pop worker] gets the next item for [worker]. *)

--- a/scheduler/pool.mli
+++ b/scheduler/pool.mli
@@ -34,6 +34,9 @@ module Make (Item : S.ITEM) (Time : S.TIME) : sig
 
     val get_rate : t -> float
     (** [get_rate t] is the rate previously set by [set_rate] (or [1.0] if never set). *)
+
+    val client_id : t -> string
+    val pool_id : t -> string
   end
 
   val create : name:string -> db:Dao.t -> t

--- a/scheduler/s.ml
+++ b/scheduler/s.ml
@@ -16,3 +16,7 @@ module type ITEM = sig
   val pp : t Fmt.t
   (** For debugging. *)
 end
+
+module type TIME = sig
+  val gettimeofday : unit -> float
+end

--- a/test/test_scheduling.ml
+++ b/test/test_scheduling.ml
@@ -10,7 +10,7 @@ module Item = struct
 
   let cache_hint t = t.cache_hint
 
-  let cost_estimate _ = Cluster_scheduler.S.{ cached = 1; non_cached = 5 }
+  let cost_estimate _ = Cluster_scheduler.S.{ cached = 2; non_cached = 10 }
 
   let pp f t = Fmt.string f t.job
 end
@@ -20,9 +20,10 @@ let job ?(cache_hint="") job = { Item.job; cache_hint }
 module Fake_time = struct
   let now = ref 1.0
 
-  let gettimeofday () =
-    now := !now +. 1.0;
-    !now
+  let gettimeofday () = !now
+
+  let advance x =
+    now := !now +. float x
 end
 
 module Pool = Cluster_scheduler.Pool.Make(Item)(Fake_time)
@@ -53,8 +54,8 @@ let with_test_db fn =
     (fun () -> fn (Cluster_scheduler.Pool.Dao.init db))
     (fun () -> if Sqlite3.db_close db then Lwt.return_unit else failwith "close: DB busy!")
 
-let submit ~urgent pool job =
-  let (_ : Pool.ticket) = Pool.submit ~urgent pool job in
+let submit ~urgent client job =
+  let (_ : Pool.ticket) = Pool.Client.submit ~urgent client job in
   ()
 
 (* Assign three jobs to two workers. *)
@@ -93,8 +94,10 @@ let cached_scheduling () =
     registered:\n\
     \  worker-1 (0): []\n\
     \  worker-2 (0): []\n\
+    clients: \n\
     cached: \n" (Fmt.to_to_string Pool.dump pool);
   let user = Pool.client pool ~client_id:"u1" in
+  Pool.Client.set_rate user 2.0;
   submit user ~urgent:false @@ job "job1" ~cache_hint:"a";
   submit user ~urgent:false @@ job "job2" ~cache_hint:"b";
   submit user ~urgent:false @@ job "job3" ~cache_hint:"a";
@@ -102,18 +105,20 @@ let cached_scheduling () =
   submit user ~urgent:false @@ job "job5" ~cache_hint:"c";
   Alcotest.(check string) "Jobs queued" "\
     capacity: 2\n\
-    queue: (backlog) [job5 job4 job3]\n\
+    queue: (backlog) [u1:job5@12s u1:job4@11s u1:job3@10s]\n\
     registered:\n\
-    \  worker-1 (5): [job1(5)]\n\
-    \  worker-2 (5): [job2(5)]\n\
+    \  worker-1 (10): [u1:job1@0s(10)]\n\
+    \  worker-2 (10): [u1:job2@5s(10)]\n\
+    clients: u1(2)+17s\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Jobs started" "\
     capacity: 2\n\
-    queue: (backlog) [job5 job4 job3]\n\
+    queue: (backlog) [u1:job5@12s u1:job4@11s u1:job3@10s]\n\
     registered:\n\
     \  worker-1 (0): []\n\
     \  worker-2 (0): []\n\
+    clients: u1(2)+17s\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Alcotest.(check pop_result) "Worker 1 / job 1" (Ok "job1") (job_state w1a);
   Alcotest.(check pop_result) "Worker 2 / job 1" (Ok "job2") (job_state w2a);
@@ -123,8 +128,9 @@ let cached_scheduling () =
     capacity: 2\n\
     queue: (backlog) []\n\
     registered:\n\
-    \  worker-1 (2): [job4(1) job3(1)]\n\
+    \  worker-1 (4): [u1:job4@11s(2) u1:job3@10s(2)]\n\
     \  worker-2 (0): []\n\
+    clients: u1(2)+17s\n\
     cached: a: [worker-1], b: [worker-2], c: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Alcotest.(check pop_result) "Worker 2 / job 2" (Ok "job5") (job_state w2b);
   (* Worker 1 leaves. Its two queued jobs get reassigned. *)
@@ -135,18 +141,21 @@ let cached_scheduling () =
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Worker-1's jobs reassigned" "\
     capacity: 1\n\
-    queue: (backlog) [job4]\n\
+    queue: (backlog) [u1:job4@11s]\n\
     registered:\n\
     \  worker-2 (0): []\n\
+    clients: u1(2)+17s\n\
     cached: a: [worker-1; worker-2], b: [worker-2], c: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Alcotest.(check pop_result) "Worker 2 / job 3" (Ok "job3") (job_state w2c);
   let w2d = Pool.pop w2 in
   Alcotest.(check pop_result) "Worker 2 / job 4" (Ok "job4") (job_state w2d);
+  Fake_time.advance 20;
   Pool.release w2;
   Alcotest.(check string) "Idle" "\
     capacity: 0\n\
     queue: (backlog) []\n\
     registered:\n\
+    clients: u1(2)\n\
     cached: a: [worker-1; worker-2], b: [worker-2], c: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Lwt.return_unit
 
@@ -159,6 +168,7 @@ let unbalanced () =
   Pool.set_active w1 true;
   Pool.set_active w2 true;
   let user = Pool.client pool ~client_id:"u1" in
+  Pool.Client.set_rate user 2.0;
   submit user ~urgent:false @@ job "job1" ~cache_hint:"a";
   submit user ~urgent:false @@ job "job2" ~cache_hint:"a";
   submit user ~urgent:false @@ job "job3" ~cache_hint:"a";
@@ -174,8 +184,10 @@ let unbalanced () =
     capacity: 2\n\
     queue: (backlog) []\n\
     registered:\n\
-    \  worker-1 (6): [job7(1) job6(1) job5(1) job4(1) job3(1) job2(1)]\n\
+    \  worker-1 (12): [u1:job7@10s(2) u1:job6@9s(2) u1:job5@8s(2) u1:job4@7s(2)\n\
+    \                  u1:job3@6s(2) u1:job2@5s(2)]\n\
     \  worker-2 (0): []\n\
+    clients: u1(2)+12s\n\
     cached: a: [worker-1; worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Alcotest.(check pop_result) "Worker 2 / job 1" (Ok "job8") (job_state w2a);
   Pool.release w1;
@@ -195,8 +207,9 @@ let no_workers () =
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Worker-1 gone" "\
     capacity: 0\n\
-    queue: (backlog) [job2]\n\
+    queue: (backlog) [u1:job2@10s]\n\
     registered:\n\
+    clients: u1(1)+12s\n\
     cached: a: [worker-1]\n" (Fmt.to_to_string Pool.dump pool);
   let w1 = Pool.register pool ~name:"worker-1" ~capacity:1 |> Result.get_ok in
   Pool.set_active w1 true;
@@ -256,9 +269,10 @@ let urgent () =
   Pool.release w1;
   Alcotest.(check string) "Worker-1 gone" "\
     capacity: 1\n\
-    queue: (backlog) [job1 job3+urgent]\n\
+    queue: (backlog) [u1:job1@0s u1:job3@12s+urgent]\n\
     registered:\n\
     \  worker-2 (0): []\n\
+    clients: u1(1)+24s\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   (* Urgent job 5 goes ahead of non-urgent job 1, but behind the existing urgent job 3. *)
   submit user ~urgent:true @@ job "job5" ~cache_hint:"b";
@@ -286,9 +300,11 @@ let urgent_worker () =
     capacity: 2\n\
     queue: (backlog) []\n\
     registered:\n\
-    \  worker-1 (1): [job2(1)]\n\
+    \  worker-1 (2): [u1:job2@10s(2)]\n\
     \  worker-2 (0): []\n\
+    clients: u1(1)+22s\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
+  Pool.Client.set_rate user 2.0;
   submit user ~urgent:true  @@ job "job4" ~cache_hint:"a";
   submit user ~urgent:false @@ job "job5" ~cache_hint:"b";
   submit user ~urgent:true  @@ job "job6" ~cache_hint:"a";
@@ -298,8 +314,9 @@ let urgent_worker () =
     capacity: 2\n\
     queue: (backlog) []\n\
     registered:\n\
-    \  worker-1 (3): [job2(1) job6(1+urgent) job4(1+urgent)]\n\
+    \  worker-1 (6): [u1:job2@10s(2) u1:job6@24s(2+urgent) u1:job4@22s(2+urgent)]\n\
     \  worker-2 (0): []\n\
+    clients: u1(2)+25s\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   flush_queue w1 ~expect:["job4"; "job6"; "job2"]
 
@@ -321,8 +338,9 @@ let inactive () =
     capacity: 2\n\
     queue: (ready) [worker-2]\n\
     registered:\n\
-    \  worker-1 (1): [job2(1)]\n\
+    \  worker-1 (2): [u1:job2@10s(2)]\n\
     \  worker-2 (0): []\n\
+    clients: u1(1)+12s\n\
     cached: a: [worker-1]\n" (Fmt.to_to_string Pool.dump pool);
   (* Deactivate worker-1. Its job is reassigned. *)
   Pool.set_active w1 false;
@@ -331,20 +349,23 @@ let inactive () =
     queue: (ready) []\n\
     registered:\n\
     \  worker-1 (0): (inactive)\n\
-    \  worker-2 (5): [job2(5)]\n\
+    \  worker-2 (10): [u1:job2@10s(10)]\n\
+    clients: u1(1)+12s\n\
     cached: a: [worker-1; worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Lwt.pause () >>= fun () ->
   Alcotest.(check pop_result) "Worker 1 / job 1" (Ok "job1") (job_state w1a);
   Alcotest.(check pop_result) "Worker 2 / job 2" (Ok "job2") (job_state w2a);
+  Pool.Client.set_rate user 2.0;
   submit user ~urgent:false @@ job "job3" ~cache_hint:"a";
   (* Deactivate worker-2. *)
   Pool.set_active w2 false;
   Alcotest.(check string) "Job unassigned" "\
     capacity: 2\n\
-    queue: (backlog) [job3]\n\
+    queue: (backlog) [u1:job3@12s]\n\
     registered:\n\
     \  worker-1 (0): (inactive)\n\
     \  worker-2 (0): (inactive)\n\
+    clients: u1(2)+13s\n\
     cached: a: [worker-1; worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Pool.set_active w2 true;
   Pool.release w1;
@@ -361,41 +382,46 @@ let cancel_worker_queue () =
   let w1a = Pool.pop w1 in
   let w2a = Pool.pop w2 in
   let user = Pool.client pool ~client_id:"u1" in
+  Pool.Client.set_rate user 2.0;
   submit user ~urgent:false @@ job "job1" ~cache_hint:"a";
   Lwt.pause () >>= fun () ->
-  let j2 = Pool.submit user ~urgent:false @@ job "job2" ~cache_hint:"a" in
-  let j3 = Pool.submit user ~urgent:false @@ job "job3" ~cache_hint:"a" in
-  let j4 = Pool.submit user ~urgent:false @@ job "job4" ~cache_hint:"b" in
-  Pool.cancel j4 |> Alcotest.(check (result pass reject)) "job4 cancelled" (Ok ());
+  let j2 = Pool.Client.submit user ~urgent:false @@ job "job2" ~cache_hint:"a" in
+  let j3 = Pool.Client.submit user ~urgent:false @@ job "job3" ~cache_hint:"a" in
+  let j4 = Pool.Client.submit user ~urgent:false @@ job "job4" ~cache_hint:"b" in
+  Pool.Client.cancel user j4 |> Alcotest.(check (result pass reject)) "job4 cancelled" (Ok ());
   Alcotest.(check string) "Jobs assigned" "\
     capacity: 2\n\
     queue: (ready) []\n\
     registered:\n\
-    \  worker-1 (2): [job3(1) job2(1)]\n\
+    \  worker-1 (4): [u1:job3@6s(2) u1:job2@5s(2)]\n\
     \  worker-2 (0): []\n\
+    clients: u1(2)+12s\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
-  Pool.cancel j2 |> Alcotest.(check (result pass reject)) "job2 cancelled" (Ok ());
+  Pool.Client.cancel user j2 |> Alcotest.(check (result pass reject)) "job2 cancelled" (Ok ());
   Alcotest.(check string) "Job2 cancelled" "\
     capacity: 2\n\
     queue: (ready) []\n\
     registered:\n\
-    \  worker-1 (1): [job3(1)]\n\
+    \  worker-1 (2): [u1:job3@6s(2)]\n\
     \  worker-2 (0): []\n\
+    clients: u1(2)+12s\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Pool.release w2;
   Pool.set_active w1 false;
   Alcotest.(check string) "Job3 pushed back" "\
     capacity: 1\n\
-    queue: (backlog) [job3]\n\
+    queue: (backlog) [u1:job3@6s]\n\
     registered:\n\
     \  worker-1 (0): (inactive)\n\
+    clients: u1(2)+12s\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
-  Pool.cancel j3 |> Alcotest.(check (result pass reject)) "job3 cancelled" (Ok ());
+  Pool.Client.cancel user j3 |> Alcotest.(check (result pass reject)) "job3 cancelled" (Ok ());
   Pool.release w1;
   Alcotest.(check string) "Job3 cancelled" "\
     capacity: 0\n\
     queue: (backlog) []\n\
     registered:\n\
+    clients: u1(2)+12s\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Alcotest.(check pop_result) "Finish worker-1" (Ok "job1") (job_state w1a);
   Alcotest.(check pop_result) "Finish worker-2" (Error "pending") (job_state w2a);
@@ -411,6 +437,7 @@ let push_back () =
   let _w1a = Pool.pop w1 in
   let _w2a = Pool.pop w2 in
   let user = Pool.client pool ~client_id:"u1" in
+  Pool.Client.set_rate user 2.0;
   submit user ~urgent:false @@ job "job1" ~cache_hint:"a";
   Lwt.pause () >>= fun () ->
   submit user ~urgent:false @@ job "job2" ~cache_hint:"a";
@@ -421,23 +448,100 @@ let push_back () =
     capacity: 2\n\
     queue: (ready) [worker-2]\n\
     registered:\n\
-    \  worker-1 (2): [job3(1) job2(1)]\n\
+    \  worker-1 (4): [u1:job3@6s(2) u1:job2@5s(2)]\n\
     \  worker-2 (0): []\n\
+    clients: u1(2)+7s\n\
     cached: a: [worker-1]\n" (Fmt.to_to_string Pool.dump pool);
   Pool.release w2;
   Pool.set_active w1 false;
   Alcotest.(check string) "Jobs pushed back" "\
     capacity: 1\n\
-    queue: (backlog) [job3 job2]\n\
+    queue: (backlog) [u1:job3@6s u1:job2@5s]\n\
     registered:\n\
     \  worker-1 (0): (inactive)\n\
+    clients: u1(2)+7s\n\
     cached: a: [worker-1]\n" (Fmt.to_to_string Pool.dump pool);
   Pool.set_active w1 true;
   flush_queue w1 ~expect:["job2"; "job3"]
 
+(* Two clients share the cluster. *)
+let fairness () =
+  with_test_db @@ fun db ->
+  let pool = Pool.create ~db ~name:"fairness" in
+  let w1 = Pool.register pool ~name:"worker-1" ~capacity:1 |> Result.get_ok in
+  let w2 = Pool.register pool ~name:"worker-2" ~capacity:1 |> Result.get_ok in
+  let alice = Pool.client pool ~client_id:"alice" in
+  let bob = Pool.client pool ~client_id:"bob" in
+  Pool.Client.set_rate alice 2.0;
+  Pool.Client.set_rate bob 2.0;
+  Pool.set_active w1 true;
+  Pool.set_active w2 true;
+  let w1a = Pool.pop w1 in
+  let w2a = Pool.pop w2 in
+  submit alice ~urgent:false @@ job "a1";
+  submit alice ~urgent:false @@ job "a2";
+  submit alice ~urgent:false @@ job "a3";
+  (* Alice's jobs a1 and a2 have already started running on the two machines,
+     and a3 is queued. Bob now submits some jobs. *)
+  submit bob ~urgent:false @@ job "b1";
+  submit bob ~urgent:false @@ job "b2";
+  submit bob ~urgent:false @@ job "b3";
+  Lwt.pause () >>= fun () ->
+  Alcotest.(check pop_result) "Worker 1 / job 1" (Ok "a1") (job_state w1a);
+  Alcotest.(check pop_result) "Worker 2 / job 1" (Ok "a2") (job_state w2a);
+  Alcotest.(check string) "Bob's jobs aren't all last" "\
+    capacity: 2\n\
+    queue: (backlog) [bob:b3@10s alice:a3@10s bob:b2@5s bob:b1@0s]\n\
+    registered:\n\
+    \  worker-1 (0): []\n\
+    \  worker-2 (0): []\n\
+    clients: alice(2)+15s bob(2)+15s\n\
+    cached: : [worker-1; worker-2]\n" (Fmt.to_to_string Pool.dump pool);
+  Pool.release w2;
+  flush_queue w1 ~expect:["b1"; "b2"; "a3"; "b3"]
+
+(* Two clients with different rates share the cluster. *)
+let fairness_rates () =
+  with_test_db @@ fun db ->
+  let pool = Pool.create ~db ~name:"fairness_rates" in
+  let w1 = Pool.register pool ~name:"worker-1" ~capacity:1 |> Result.get_ok in
+  let w2 = Pool.register pool ~name:"worker-2" ~capacity:1 |> Result.get_ok in
+  let alice = Pool.client pool ~client_id:"alice" in
+  let bob = Pool.client pool ~client_id:"bob" in
+  Pool.Client.set_rate alice 5.0;
+  Pool.Client.set_rate bob 1.0;
+  Pool.set_active w1 true;
+  Pool.set_active w2 true;
+  let w1a = Pool.pop w1 in
+  let w2a = Pool.pop w2 in
+  (* Alice submits 30s worth of work, but using 5 machines expects to take 6s. *)
+  submit alice ~urgent:false @@ job "a1";
+  submit alice ~urgent:false @@ job "a2";
+  submit alice ~urgent:false @@ job "a3";
+  (* Alice's jobs a1 and a2 have already started running on the two machines,
+     and a3 is queued. Bob now submits some jobs. It's the same amount of work,
+     but with the lower rate, Bob expects his jobs to take 30s. *)
+  submit bob ~urgent:false @@ job "b1";
+  submit bob ~urgent:false @@ job "b2";
+  submit bob ~urgent:false @@ job "b3";
+  Lwt.pause () >>= fun () ->
+  Alcotest.(check pop_result) "Worker 1 / job 1" (Ok "a1") (job_state w1a);
+  Alcotest.(check pop_result) "Worker 2 / job 1" (Ok "a2") (job_state w2a);
+  Alcotest.(check string) "Bob's jobs aren't all last" "\
+    capacity: 2\n\
+    queue: (backlog) [bob:b3@20s bob:b2@10s alice:a3@4s bob:b1@0s]\n\
+    registered:\n\
+    \  worker-1 (0): []\n\
+    \  worker-2 (0): []\n\
+    clients: alice(5)+6s bob(1)+30s\n\
+    cached: : [worker-1; worker-2]\n" (Fmt.to_to_string Pool.dump pool);
+  Pool.release w2;
+  flush_queue w1 ~expect:["b1"; "a3"; "b2"; "b3"]
+
 let test_case name fn =
   Alcotest_lwt.test_case name `Quick @@ fun _ () ->
   Lwt_unix.yield () >>= fun () ->       (* Ensure we're inside the Lwt mainloop. Lwt.pause behaves strangely otherwise. *)
+  Fake_time.now := 1.0;
   fn () >>= fun () ->
   Lwt.pause () >|= fun () ->
   Prometheus.CollectorRegistry.(collect default)
@@ -465,4 +569,6 @@ let suite = [
   test_case "inactive" inactive;
   test_case "cancel_worker_queue" cancel_worker_queue;
   test_case "push_back" push_back;
+  test_case "fairness" fairness;
+  test_case "fairness_rates" fairness_rates;
 ]

--- a/test/test_scheduling.ml
+++ b/test/test_scheduling.ml
@@ -82,8 +82,8 @@ let cached_scheduling () =
     capacity: 2\n\
     queue: (ready) [worker-2 worker-1]\n\
     registered:\n\
-    \  worker-1 (0): [] : []\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-1 (0): []\n\
+    \  worker-2 (0): []\n\
     cached: \n" (Fmt.to_to_string Pool.dump pool);
   submit pool ~urgent:false @@ job "job1" ~cache_hint:"a";
   submit pool ~urgent:false @@ job "job2" ~cache_hint:"b";
@@ -92,18 +92,18 @@ let cached_scheduling () =
   submit pool ~urgent:false @@ job "job5" ~cache_hint:"c";
   Alcotest.(check string) "Jobs queued" "\
     capacity: 2\n\
-    queue: (backlog) [job5 job4 job3] : []\n\
+    queue: (backlog) [job5 job4 job3]\n\
     registered:\n\
-    \  worker-1 (5): [job1(5)] : []\n\
-    \  worker-2 (5): [job2(5)] : []\n\
+    \  worker-1 (5): [job1(5)]\n\
+    \  worker-2 (5): [job2(5)]\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Jobs started" "\
     capacity: 2\n\
-    queue: (backlog) [job5 job4 job3] : []\n\
+    queue: (backlog) [job5 job4 job3]\n\
     registered:\n\
-    \  worker-1 (0): [] : []\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-1 (0): []\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Alcotest.(check pop_result) "Worker 1 / job 1" (Ok "job1") (job_state w1a);
   Alcotest.(check pop_result) "Worker 2 / job 1" (Ok "job2") (job_state w2a);
@@ -111,10 +111,10 @@ let cached_scheduling () =
   let w2b = Pool.pop w2 in
   Alcotest.(check string) "Jobs 3 and 4 assigned to worker-1" "\
     capacity: 2\n\
-    queue: (backlog) [] : []\n\
+    queue: (backlog) []\n\
     registered:\n\
-    \  worker-1 (2): [job4(1) job3(1)] : []\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-1 (2): [job4(1) job3(1)]\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1], b: [worker-2], c: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Alcotest.(check pop_result) "Worker 2 / job 2" (Ok "job5") (job_state w2b);
   (* Worker 1 leaves. Its two queued jobs get reassigned. *)
@@ -125,9 +125,9 @@ let cached_scheduling () =
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Worker-1's jobs reassigned" "\
     capacity: 1\n\
-    queue: (backlog) [job4] : []\n\
+    queue: (backlog) [job4]\n\
     registered:\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1; worker-2], b: [worker-2], c: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Alcotest.(check pop_result) "Worker 2 / job 3" (Ok "job3") (job_state w2c);
   let w2d = Pool.pop w2 in
@@ -135,7 +135,7 @@ let cached_scheduling () =
   Pool.release w2;
   Alcotest.(check string) "Idle" "\
     capacity: 0\n\
-    queue: (backlog) [] : []\n\
+    queue: (backlog) []\n\
     registered:\n\
     cached: a: [worker-1; worker-2], b: [worker-2], c: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Lwt.return_unit
@@ -161,10 +161,10 @@ let unbalanced () =
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Worker-2 got jobs eventually" "\
     capacity: 2\n\
-    queue: (backlog) [] : []\n\
+    queue: (backlog) []\n\
     registered:\n\
-    \  worker-1 (6): [job7(1) job6(1) job5(1) job4(1) job3(1) job2(1)] : []\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-1 (6): [job7(1) job6(1) job5(1) job4(1) job3(1) job2(1)]\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1; worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Alcotest.(check pop_result) "Worker 2 / job 1" (Ok "job8") (job_state w2a);
   Pool.release w1;
@@ -183,7 +183,7 @@ let no_workers () =
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Worker-1 gone" "\
     capacity: 0\n\
-    queue: (backlog) [job2] : []\n\
+    queue: (backlog) [job2]\n\
     registered:\n\
     cached: a: [worker-1]\n" (Fmt.to_to_string Pool.dump pool);
   let w1 = Pool.register pool ~name:"worker-1" ~capacity:1 |> Result.get_ok in
@@ -239,9 +239,9 @@ let urgent () =
   Pool.release w1;
   Alcotest.(check string) "Worker-1 gone" "\
     capacity: 1\n\
-    queue: (backlog) [job1] : [job3]\n\
+    queue: (backlog) [job1 job3+urgent]\n\
     registered:\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   (* Urgent job 5 goes ahead of non-urgent job 1, but behind the existing urgent job 3. *)
   submit pool ~urgent:true @@ job "job5" ~cache_hint:"b";
@@ -266,10 +266,10 @@ let urgent_worker () =
   Alcotest.(check pop_result) "Worker 2 / job 1" (Ok "job3") (job_state w2a);
   Alcotest.(check string) "Worker-1 queue has job 2 queued" "\
     capacity: 2\n\
-    queue: (backlog) [] : []\n\
+    queue: (backlog) []\n\
     registered:\n\
-    \  worker-1 (1): [job2(1)] : []\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-1 (1): [job2(1)]\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   submit pool ~urgent:true  @@ job "job4" ~cache_hint:"a";
   submit pool ~urgent:false @@ job "job5" ~cache_hint:"b";
@@ -278,10 +278,10 @@ let urgent_worker () =
   Alcotest.(check pop_result) "Worker 2 / job 2" (Ok "job5") (job_state w2b);
   Alcotest.(check string) "Worker-1 gets job4 first" "\
     capacity: 2\n\
-    queue: (backlog) [] : []\n\
+    queue: (backlog) []\n\
     registered:\n\
-    \  worker-1 (3): [job2(1)] : [job6(1+urgent) job4(1+urgent)]\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-1 (3): [job2(1) job6(1+urgent) job4(1+urgent)]\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   flush_queue w1 ~expect:["job4"; "job6"; "job2"]
 
@@ -302,8 +302,8 @@ let inactive () =
     capacity: 2\n\
     queue: (ready) [worker-2]\n\
     registered:\n\
-    \  worker-1 (1): [job2(1)] : []\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-1 (1): [job2(1)]\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1]\n" (Fmt.to_to_string Pool.dump pool);
   (* Deactivate worker-1. Its job is reassigned. *)
   Pool.set_active w1 false;
@@ -312,7 +312,7 @@ let inactive () =
     queue: (ready) []\n\
     registered:\n\
     \  worker-1 (0): (inactive)\n\
-    \  worker-2 (5): [job2(5)] : []\n\
+    \  worker-2 (5): [job2(5)]\n\
     cached: a: [worker-1; worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Lwt.pause () >>= fun () ->
   Alcotest.(check pop_result) "Worker 1 / job 1" (Ok "job1") (job_state w1a);
@@ -322,7 +322,7 @@ let inactive () =
   Pool.set_active w2 false;
   Alcotest.(check string) "Job unassigned" "\
     capacity: 2\n\
-    queue: (backlog) [job3] : []\n\
+    queue: (backlog) [job3]\n\
     registered:\n\
     \  worker-1 (0): (inactive)\n\
     \  worker-2 (0): (inactive)\n\
@@ -351,22 +351,22 @@ let cancel_worker_queue () =
     capacity: 2\n\
     queue: (ready) []\n\
     registered:\n\
-    \  worker-1 (2): [job3(1) job2(1)] : []\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-1 (2): [job3(1) job2(1)]\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Pool.cancel j2 |> Alcotest.(check (result pass reject)) "job2 cancelled" (Ok ());
   Alcotest.(check string) "Job2 cancelled" "\
     capacity: 2\n\
     queue: (ready) []\n\
     registered:\n\
-    \  worker-1 (1): [job3(1)] : []\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-1 (1): [job3(1)]\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Pool.release w2;
   Pool.set_active w1 false;
   Alcotest.(check string) "Job3 pushed back" "\
     capacity: 1\n\
-    queue: (backlog) [job3] : []\n\
+    queue: (backlog) [job3]\n\
     registered:\n\
     \  worker-1 (0): (inactive)\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
@@ -374,7 +374,7 @@ let cancel_worker_queue () =
   Pool.release w1;
   Alcotest.(check string) "Job3 cancelled" "\
     capacity: 0\n\
-    queue: (backlog) [] : []\n\
+    queue: (backlog) []\n\
     registered:\n\
     cached: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Alcotest.(check pop_result) "Finish worker-1" (Ok "job1") (job_state w1a);
@@ -400,14 +400,14 @@ let push_back () =
     capacity: 2\n\
     queue: (ready) [worker-2]\n\
     registered:\n\
-    \  worker-1 (2): [job3(1) job2(1)] : []\n\
-    \  worker-2 (0): [] : []\n\
+    \  worker-1 (2): [job3(1) job2(1)]\n\
+    \  worker-2 (0): []\n\
     cached: a: [worker-1]\n" (Fmt.to_to_string Pool.dump pool);
   Pool.release w2;
   Pool.set_active w1 false;
   Alcotest.(check string) "Jobs pushed back" "\
     capacity: 1\n\
-    queue: (backlog) [job3 job2] : []\n\
+    queue: (backlog) [job3 job2]\n\
     registered:\n\
     \  worker-1 (0): (inactive)\n\
     cached: a: [worker-1]\n" (Fmt.to_to_string Pool.dump pool);


### PR DESCRIPTION
This adds some experimental support for fair queuing. This should allow e.g. the base-image builder and opam-health-check to submit lots of jobs at once, without starving each other or other users.

At the moment, there's no feedback to compare the estimated job times to the actual ones. I'm not sure how much that will matter though, so let's try it this way first.

It needs a bit more testing before deployment. And also more metrics to show what's happening.