### PR TITLE
Add stress testbed

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The scheduler tries to schedule similar builds on the same machine, to benefit f
 * [API](#api)
 * [Security model](#security-model)
 * [Prometheus metrics](#prometheus-metrics)
+* [Testing](#testing)
 
 <!-- vim-markdown-toc -->
 
@@ -320,5 +321,37 @@ The endpoints available are:
 
 The worker agent and worker host metrics are fetched over the worker's Cap'n Proto connection, so there is no need
 to allow incoming network connections to the workers for this.
+
+## Testing
+
+The `stress` directory contains some code for running the scheduler with some simulated workloads and monitoring it.
+To save building things again, `stress/docker-compose.yml` runs the previously-built scheduler binary directly from `_build`,
+which therefore needs to be compatible with the `stress/Dockerfile` environment (so edit that if it doesn't match your
+main dev platform).
+
+To run the testbed:
+
+```
+dune build
+cd stress
+docker-compose up
+```
+
+This runs three services:
+- `scheduler` is a scheduler instance with some dummy workers that handle jobs by just sleeping for a bit,
+  and some dummy clients that submit jobs to the cluster.
+- `prometheus` collects metrics from the scheduler.
+- `grafana` displays the metrics.
+
+Open <http://localhost:3000> in a web-browser to view the grafana dashboard for the tests.
+
+The `scheduler` service also writes out `./capnp-secrets/stress-admin.cap`, which you can use from the host to manage the test cluster.
+For example:
+
+```
+dune exec -- ocluster-admin show ./capnp-secrets/stress-admin.cap linux-x86_64
+```
+
+You can also create your own client endpoints and submit your own jobs, in addition to those submitted by the testbed itself.
 
 [OBuilder]: https://github.com/ocurrent/obuilder

--- a/stress/Dockerfile
+++ b/stress/Dockerfile
@@ -1,0 +1,2 @@
+FROM debian:10
+RUN apt-get update && apt-get install libev4 libsqlite3-0 -y --no-install-recommends

--- a/stress/ci.ml
+++ b/stress/ci.ml
@@ -1,0 +1,35 @@
+(* ocaml-ci submits a steady stream of small jobs, plus occasional large batches due to opam-repository updates. *)
+
+open Lwt.Infix
+
+let platforms = ["fedora-31"; "fedora-32"; "debian-9"; "debian-10"; "opensuse"; "ubuntu"; "ubuntu-lts"]
+
+let n_targets = 300
+
+(* Submit one job for each platform *)
+let submit_batch ~i ~pkg ~urgent submit_cap =
+  platforms
+  |> List.map (fun platform ->
+      let cache_hint = Printf.sprintf "%d-%d-%s" !Utils.opam_repo_head pkg platform in
+      Utils.submit submit_cap ~name:"ocaml-ci" ~i ~pool:"linux-x86_64" ~urgent ~cache_hint
+    )
+  |> Lwt.join
+
+let thread submit_cap =
+  let i = ref 0 in
+  let rec aux () =
+    Utils.sleep (Duration.of_min 10) >>= fun () ->
+    let pkg = Random.int n_targets in
+    Lwt.async (fun () -> submit_batch ~i ~pkg ~urgent:true submit_cap);
+    aux ()
+  in
+  let rec opam_repo () =
+    Lwt_condition.wait Utils.opam_repository_updated >>= fun () ->
+    List.init (Random.int n_targets) (fun pkg -> submit_batch ~i ~pkg ~urgent:false submit_cap)
+    |> Lwt.join
+    >>= opam_repo
+  in
+  Lwt.choose [
+    aux ();
+    opam_repo ();
+  ]

--- a/stress/docker-compose.yml
+++ b/stress/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.8"
+services:
+  scheduler:
+    build:
+      context: ..
+      dockerfile: stress/Dockerfile
+    command: /opt/stress/stress.exe --listen-prometheus=9090
+    init: true
+    ports:
+      - "5000:5000"
+    volumes:
+      - "../capnp-secrets:/capnp-secrets"
+      - "../_build/default/stress:/opt/stress:ro"
+  grafana:
+    build: './grafana'
+    ports:
+      - "3000:3000"
+    #volumes:
+    #  - "./grafana-config:/var/lib/grafana"
+  prometheus:
+    image: prom/prometheus
+    command: --storage.tsdb.retention.time=30w --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles
+    #ports:
+    #  - "9090:9090"
+    volumes:
+      - "prometheus-data:/prometheus"
+      - "./prometheus:/etc/prometheus:ro"
+volumes:
+  prometheus-data:

--- a/stress/dune
+++ b/stress/dune
@@ -1,0 +1,14 @@
+(executable
+  (name stress)
+  (libraries
+    cmdliner
+    capnp-rpc-net
+    capnp-rpc-unix
+    cluster_scheduler
+    db
+    fmt.tty
+    logs.fmt
+    lwt.unix
+    prometheus-app.unix))
+
+(dirs)

--- a/stress/grafana/Dockerfile
+++ b/stress/grafana/Dockerfile
@@ -1,0 +1,4 @@
+FROM grafana/grafana:7.3.4
+ADD ./provisioning /etc/grafana/provisioning
+ADD ./grafana.ini /etc/grafana/grafana.ini
+ADD ./dashboards/ocluster.json /etc/grafana/ocluster.json

--- a/stress/grafana/dashboards/ocluster.json
+++ b/stress/grafana/dashboards/ocluster.json
@@ -1,0 +1,707 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 10,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": true,
+      "targets": [
+        {
+          "expr": "ocluster_pool_queue_length",
+          "interval": "",
+          "legendFormat": "{{pool}}-{{queue}}-{{priority}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Queue length",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ocluster_pool_workers_connected",
+          "interval": "",
+          "legendFormat": "{{pool}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Workers connected",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 10,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ocluster_worker_running_jobs",
+          "interval": "",
+          "legendFormat": "{{worker}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Running jobs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total[5m])",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": "1",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ocluster_scheduler_client_submitted_jobs",
+          "interval": "",
+          "legendFormat": "{{client}}-{{pool}}-{{priority}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Submitted jobs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ocaml_gc_heap_words * 8",
+          "interval": "",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "OCaml heap",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ocluster_pool_jobs_accepted_total",
+          "interval": "",
+          "legendFormat": "{{pool}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Jobs started",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Overview",
+  "uid": "5e9rmFoGz",
+  "version": 15
+}

--- a/stress/grafana/grafana.ini
+++ b/stress/grafana/grafana.ini
@@ -1,0 +1,14 @@
+[analytics]
+reporting_enabled = false
+check_for_updates = false
+
+[auth]
+disable_login_form = true
+
+[auth.anonymous]
+enabled = true
+org_role = Editor
+#org_role = Admin
+
+[dashboards]
+default_home_dashboard_path = /etc/grafana/ocluster.json

--- a/stress/grafana/provisioning/datasources/all.yml
+++ b/stress/grafana/provisioning/datasources/all.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    version: 1
+    editable: false

--- a/stress/health_check.ml
+++ b/stress/health_check.ml
@@ -1,0 +1,27 @@
+(* opam-health-check submits the whole of opam repository at once. *)
+
+open Lwt.Infix
+
+let platforms = ["fedora-31"; "fedora-32"; "debian-9"; "debian-10"; "opensuse"; "ubuntu"; "ubuntu-lts"]
+
+let n_packages = 3000
+
+(* Submit one job for each platform *)
+let submit_batch ~i ~pkg submit_cap =
+  platforms
+  |> List.map (fun platform ->
+      let cache_hint = Printf.sprintf "%d-%d-%s" !Utils.opam_repo_head pkg platform in
+      Utils.submit submit_cap ~name:"opam-health-check" ~i ~pool:"linux-x86_64" ~urgent:false ~cache_hint
+    )
+  |> Lwt.join
+
+let thread submit_cap =
+  let i = ref 0 in
+  let rec aux () =
+    Logs.info (fun f -> f "Health-check time!");
+    List.init n_packages (fun pkg -> submit_batch ~i ~pkg submit_cap) |>
+    Lwt.join >>= fun () ->
+    Utils.sleep (Duration.of_hour 4) >>= fun () ->
+    aux ()
+  in
+  aux ()

--- a/stress/prometheus/prometheus.yml
+++ b/stress/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval:     10s
+  evaluation_interval: 10s
+  # scrape_timeout is set to the global default (10s).
+
+scrape_configs:
+  - job_name: 'scheduler'
+    static_configs:
+    - targets: ['scheduler:9090']

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -1,0 +1,92 @@
+open Capnp_rpc_lwt
+open Lwt.Infix
+
+module Restorer = Capnp_rpc_net.Restorer
+
+module Api = Cluster_api
+
+let () =
+  Printexc.record_backtrace true
+
+let reporter =
+  let report src level ~over k msgf =
+    let k _ = over (); k () in
+    let src = Logs.Src.name src in
+    msgf @@ fun ?header ?tags:_ fmt ->
+    Fmt.kpf k Fmt.stdout ("%a %a @[" ^^ fmt ^^ "@]@.")
+      Fmt.(styled `Magenta string) (Printf.sprintf "%14s" src)
+      Logs_fmt.pp_header (level, header)
+  in
+  { Logs.report = report }
+
+let () =
+  Fmt_tty.setup_std_outputs ();
+  Logs.(set_level (Some Info));
+  Logs.set_reporter reporter
+
+let or_die = function
+  | Ok x -> x
+  | Error (`Msg m) -> failwith m
+
+let rec opam_repo_update () =
+  Utils.sleep (Duration.of_sec 10) >>= fun () ->
+  Utils.update_opam_repository ();
+  Utils.sleep (Duration.of_hour 1) >>= opam_repo_update
+
+let main prometheus_config =
+  let vat_config =
+    let socket = Capnp_rpc_unix.Network.Location.tcp ~host:"0.0.0.0" ~port:5000  in
+    Capnp_rpc_unix.Vat_config.create socket
+      ~secret_key:`Ephemeral
+      ~serve_tls:false
+      ~public_address:socket
+  in
+  Lwt_main.run begin
+    Mirage_crypto_rng_lwt.initialize ();
+    let db = Sqlite3.db_open ":memory:" in
+    Lwt.finalize (fun () ->
+        let sched = Cluster_scheduler.create ~db ["linux-x86_64"] in
+        let load ~validate ~sturdy_ref = function
+          | Cluster_scheduler.Client, name ->
+            Lwt.return @@ Restorer.grant (Cluster_scheduler.submission_service ~validate ~sturdy_ref sched name)
+          | (ty, _) -> Fmt.failwith "Unknown SturdyRef type %a found in database!" Cluster_scheduler.Sqlite_loader.Ty.pp ty
+        in
+        let make_sturdy = Capnp_rpc_unix.Vat_config.sturdy_uri vat_config in
+        let loader = Cluster_scheduler.Sqlite_loader.create ~make_sturdy ~load db in
+        let services = Restorer.Table.of_loader (module Cluster_scheduler.Sqlite_loader) loader in
+        let restore = Restorer.of_table services in
+        Capnp_rpc_unix.serve ~restore vat_config >>= fun vat ->
+        Capability.with_ref (Cluster_scheduler.admin_service ~loader ~restore sched) @@ fun admin ->
+        let admin_id = Restorer.Id.public "admin" in
+        Restorer.Table.add services admin_id admin;
+        Capnp_rpc_unix.Cap_file.save_service vat admin_id "./capnp-secrets/stress-admin.cap" |> or_die;
+        Capability.with_ref (Api.Admin.add_client admin "ocaml-ci") @@ fun ocaml_ci ->
+        Capability.with_ref (Api.Admin.add_client admin "health") @@ fun health ->
+        Capability.with_ref (Api.Admin.pool admin "linux-x86_64") @@ fun x86_64_admin ->
+        Api.Pool_admin.set_rate x86_64_admin ~client_id:"ocaml-ci" 100.0 >>= fun () ->
+        match Cluster_scheduler.registration_services sched with
+        | [] | _ :: _ :: _ -> assert false
+        | [(_, x86_64_reg)] ->
+          Capability.with_ref x86_64_reg @@ fun x86_64_reg ->
+          Lwt.choose ([
+              Ci.thread ocaml_ci;
+              Health_check.thread health;
+              opam_repo_update ();
+              Worker.thread x86_64_reg ~name:"build1" ~capacity:32;
+              Worker.thread x86_64_reg ~name:"build2" ~capacity:64;
+              Worker.thread x86_64_reg ~name:"build3" ~capacity:64;
+              Worker.thread x86_64_reg ~name:"build4" ~capacity:64;
+              Worker.thread x86_64_reg ~name:"build5" ~capacity:128;
+            ] @ Prometheus_unix.serve prometheus_config)
+      )
+      (fun () -> if Sqlite3.db_close db then Lwt.return_unit else failwith "close: DB busy!")
+  end
+
+open Cmdliner
+
+let cmd =
+  let doc = "Test the scheduler" in
+  Term.(const main $ Prometheus_unix.opts),
+  Term.info "stress" ~doc
+
+let () = Term.(exit @@ eval cmd)

--- a/stress/utils.ml
+++ b/stress/utils.ml
@@ -1,0 +1,29 @@
+open Lwt.Infix
+open Capnp_rpc_lwt
+
+module Api = Cluster_api
+
+let speed_multiplier = 60.0
+
+let sleep d =
+  Lwt_unix.sleep (Duration.to_f d /. speed_multiplier)
+
+let submit cap ~name ~i ~pool ~urgent ~cache_hint =
+  let job_id = Printf.sprintf "%s-%d" name !i in
+  incr i;
+  let descr = Api.Submission.obuilder_build job_id in
+  Capability.with_ref (Api.Submission.submit cap ~action:descr ~pool ~urgent ~cache_hint) @@ fun ticket ->
+  Capability.with_ref (Api.Ticket.job ticket) @@ fun job ->
+  Capability.wait_until_settled job >>= fun () ->
+  Logs.info (fun f -> f "%s: job %S running" name job_id);
+  Api.Job.result job >|= function
+  | Ok _ -> Logs.info (fun f -> f "%s : job %S finished" name job_id);
+  | Error (`Capnp ex) -> Logs.info (fun f -> f "%s: job %S failed: %a" name job_id Capnp_rpc.Error.pp ex)
+
+let opam_repo_head = ref 0
+
+let opam_repository_updated : unit Lwt_condition.t = Lwt_condition.create ()
+
+let update_opam_repository () =
+  incr opam_repo_head;
+  Lwt_condition.broadcast opam_repository_updated ()

--- a/stress/worker.ml
+++ b/stress/worker.ml
@@ -1,0 +1,76 @@
+open Lwt.Infix
+open Capnp_rpc_lwt
+
+module Api = Cluster_api
+
+module Metrics = struct
+  open Prometheus
+
+  let namespace = "ocluster"
+  let subsystem = "worker"
+
+  let running_jobs =
+    let help = "Number of jobs currently running" in
+    Gauge.v_label ~label_name:"worker" ~help ~namespace ~subsystem "running_jobs"
+end
+
+module Hint_set = Set.Make(String)
+
+type t = {
+  name : string;
+  capacity : int;
+  mutable in_use : int;                (* Number of active builds *)
+  cond : unit Lwt_condition.t;         (* Fires when a build finishes (or switch turned off) *)
+  mutable cached : Hint_set.t;
+}
+
+let thread ~name ~capacity pool =
+  let src = Logs.Src.create name ~doc:"fake worker" in
+  let (module Log : Logs.LOG) = Logs.src_log src in
+  let worker =
+    let metrics _ = failwith "fake metrics" in
+    let self_update _ = failwith "fake self_update" in
+    Api.Worker.local ~metrics ~self_update
+  in
+  Capability.with_ref (Api.Registration.register pool ~name ~capacity worker) @@ fun queue ->
+  let t = { name; capacity; in_use = 0; cond = Lwt_condition.create (); cached = Hint_set.empty } in
+  let rec loop () =
+    if t.in_use >= t.capacity then (
+      Log.info (fun f -> f "At capacity. Waiting for a build to finish before requesting more...");
+      Lwt_condition.wait t.cond >>= loop
+    ) else (
+      let outcome, set_outcome = Lwt.wait () in
+      Log.info (fun f -> f "Requesting a new job...");
+      let switch = Lwt_switch.create () in
+      let pop =
+        let stream_log_data ~start:_ = 
+          outcome >>= fun _ ->
+          Lwt.return ("", 0L)
+        in
+        Capability.with_ref (Cluster_api.Job.local ~switch ~outcome ~stream_log_data) @@ fun job ->
+        Cluster_api.Queue.pop queue job
+      in
+      pop >>= fun request ->
+      let cache_hint = Cluster_api.Raw.Reader.JobDescr.cache_hint_get request in
+      let is_cached = Hint_set.mem cache_hint t.cached in
+      t.cached <- Hint_set.add cache_hint t.cached;
+      t.in_use <- t.in_use + 1;
+      Prometheus.Gauge.inc_one (Metrics.running_jobs name);
+      Lwt.async (fun () ->
+          Lwt.finalize
+            (fun () ->
+               let d = if is_cached then Duration.of_sec 15 else Duration.of_min 15 in
+               Utils.sleep d >>= fun () ->
+               Lwt.wakeup set_outcome (Ok "");
+               Lwt.return_unit)
+            (fun () ->
+               t.in_use <- t.in_use - 1;
+               Prometheus.Gauge.dec_one (Metrics.running_jobs name);
+               Lwt_switch.turn_off switch >>= fun () ->
+               Lwt_condition.broadcast t.cond ();
+               Lwt.return_unit)
+        );
+      loop ()
+    )
+  in
+  loop ()


### PR DESCRIPTION
This adds a `stress` directory with a docker-compose file that runs the scheduler with a test load, along with prometheus and grafana services for monitoring it. It may be useful for checking that the scheduler can handle a particular load.