### PR TITLE
Add --default-clients option to scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ dune exec -- ocluster-admin add-client ./capnp-secrets/admin.cap alice > alice.c
 You can also use `remove-client` to deactivate the `.cap` file, and `list-clients` to
 show all registered users.
 
+For automated deployment scripts, you can also start the scheduler with e.g.
+`--default-clients=alice,bob` to create `alice.cap` and `bob.cap` automatically
+if they don't already exist.
+
 To get a list of the available pools:
 
 ```


### PR DESCRIPTION
If the scheduler is started with `--default-clients=foo,bar` then it will create new clients `foo` and `bar` and write their cap files as `submit-foo.cap` and `submit-bar.cap` to the secrets directory.

This is useful for automated deployments (and in particular for setting up test schedulers with e.g. docker-compose).