### PR TITLE
Enable OBuilder healthchecks

### DIFF
--- a/worker/obuilder_build.mli
+++ b/worker/obuilder_build.mli
@@ -13,3 +13,5 @@ val build : t ->
   log:Log_data.t ->
   spec:Obuilder.Spec.t ->
   src_dir:string -> (string, [ `Cancelled | `Msg of string ]) Lwt_result.t
+
+val healthcheck : t -> (unit, [> `Msg of string]) Lwt_result.t


### PR DESCRIPTION
Check that the system is healthy on start-up (and refuse to start if not). Then check system health every 10 minutes and report it as a Prometheus metric. If the system becomes unhealthy, the worker pauses itself until it becomes healthy again.
