### PR TITLE
Add support for secrets

### DIFF
--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -41,6 +41,14 @@ struct OBuilder {
   # The contents of the OBuilder spec to build.
 }
 
+struct Secret {
+  id @0 :Text;
+  # The secret id.
+
+  value @1 :Text;
+  # The secret value.
+}
+
 struct JobDescr {
   action :union {
     dockerBuild @0 :DockerBuild;
@@ -57,6 +65,9 @@ struct JobDescr {
   commits @3 :List(Text);
   # The commit(s) to use as the context. If the list is empty, there will be no context.
   # If there are multiple items, they will be merged.
+
+  secrets @5 :List(Secret);
+  # Secret id-value pairs provided to the job. 
 }
 
 interface Job {

--- a/bin/client.ml
+++ b/bin/client.ml
@@ -40,6 +40,7 @@ type submit_options_common = {
   commits : string list;
   cache_hint : string;
   urgent : bool;
+  secrets : (string * string) list;
 }
 
 let get_action = function
@@ -55,7 +56,7 @@ let get_action = function
     Lwt_io.(with_file ~mode:input) path (Lwt_io.read ?count:None) >|= fun spec ->
     Cluster_api.Submission.obuilder_build spec
 
-let submit { submission_path; pool; repository; commits; cache_hint; urgent } spec =
+let submit { submission_path; pool; repository; commits; cache_hint; urgent; secrets } spec =
   let src =
     match repository, commits with
     | None, [] -> None
@@ -65,7 +66,7 @@ let submit { submission_path; pool; repository; commits; cache_hint; urgent } sp
   in
   run submission_path @@ fun submission_service ->
   get_action spec >>= fun action ->
-  Capability.with_ref (Cluster_api.Submission.submit submission_service ~urgent ~pool ~action ~cache_hint ?src) @@ fun ticket ->
+  Capability.with_ref (Cluster_api.Submission.submit submission_service ~urgent ~pool ~action ~cache_hint ~secrets ?src) @@ fun ticket ->
   Capability.with_ref (Cluster_api.Ticket.job ticket) @@ fun job ->
   let result = Cluster_api.Job.result job in
   Fmt.pr "Tailing log:@.";
@@ -195,6 +196,15 @@ let build_args =
     ~docv:"ARG"
     ["build-arg"]
 
+let secrets =
+  (Arg.value @@
+  Arg.(opt_all string) [] @@
+  Arg.info
+    ~doc:"Provide secret under the form key=value"
+    ~docv:"SECRET"
+    ["secret"])
+  |> Term.(app (const (List.filter_map (Astring.String.cut ~sep:"="))))
+
 let squash =
   Arg.value @@
   Arg.flag @@
@@ -239,10 +249,10 @@ let build_options =
   Term.(pure make $ build_args $ squash $ buildkit $ include_git)
 
 let submit_options_common =
-  let make submission_path pool repository commits cache_hint urgent =
-    { submission_path; pool; repository; commits; cache_hint; urgent }
+  let make submission_path pool repository commits cache_hint urgent secrets =
+    { submission_path; pool; repository; commits; cache_hint; urgent; secrets }
   in
-  Term.(pure make $ connect_addr $ pool $ repo $ commits $ cache_hint $ urgent)
+  Term.(pure make $ connect_addr $ pool $ repo $ commits $ cache_hint $ urgent $ secrets)
 
 let submit_docker_options =
   let make dockerfile push_to build_options =

--- a/ocurrent-plugin/connection.mli
+++ b/ocurrent-plugin/connection.mli
@@ -21,6 +21,7 @@ val pool :
   action:Cluster_api.Submission.action ->
   cache_hint:string ->
   ?src:string * string list ->
+  ?secrets:(string * string) list ->
   ?urgent:([`High | `Low] -> bool) ->
   t ->
   Cluster_api.Raw.Client.Job.t Capnp_rpc_lwt.Capability.t Current.Pool.t

--- a/ocurrent-plugin/current_ocluster.mli
+++ b/ocurrent-plugin/current_ocluster.mli
@@ -15,11 +15,13 @@ type urgency = [
 val v :
   ?timeout:Duration.t ->
   ?push_auth:(string * string) ->
+  ?secrets:(string * string) list ->
   ?urgent:urgency ->
   Connection.t ->
   t
 (** [v conn] is a builder that submits jobs using [conn].
     @param push_auth : the username and password to use when pushing to the Docker Hub staging area.
+    @param secrets : secrets to pass to the job as (id, value) pairs.
     @param timeout : default timeout
     @param urgent : when to mark builds as urgent (default [`Auto]). *)
 
@@ -30,6 +32,10 @@ val with_timeout : Duration.t option -> t -> t
 val with_push_auth : (string * string) option -> t -> t
 (** [with_push_auth x t] is a copy of [t] with the specified push settings, but still
     sharing the same connection. *)
+
+val with_secrets : (string * string) list -> t -> t
+(** [with_secrets x t] is a copy of [t] with the specified secrets, but still sharing
+    the same connection. *)
 
 val with_urgent : urgency -> t -> t
 (** [with_urgent x t] is a copy of [t] with urgency policy [x]. *)

--- a/test/mock_builder.ml
+++ b/test/mock_builder.ml
@@ -34,7 +34,7 @@ let rec await t id =
     Lwt_condition.wait t.cond >>= fun () ->
     await t id
 
-let docker_build t ~switch ~log ~src:_ = function
+let docker_build t ~switch ~log ~src:_ ~secrets:_ = function
   | `Obuilder _ -> assert false
   | `Docker (dockerfile, _options) ->
     match dockerfile with

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -14,6 +14,7 @@ val run :
   ?build:(switch:Lwt_switch.t ->
           log:Log_data.t ->
           src:string ->
+          secrets:(string * string) list ->
           job_spec ->
           (string, [`Cancelled | `Msg of string]) Lwt_result.t) ->
   ?allow_push:string list ->

--- a/worker/obuilder_build.ml
+++ b/worker/obuilder_build.ml
@@ -110,10 +110,10 @@ let check_free_space t =
     in
     aux ()
 
-let build t ~switch ~log ~spec ~src_dir =
+let build t ~switch ~log ~spec ~src_dir ~secrets =
   check_free_space t >>= fun () ->
   let log = log_to log in
-  let context = Obuilder.Context.v ~switch ~log ~src_dir () in
+  let context = Obuilder.Context.v ~switch ~log ~src_dir ~secrets () in
   let Builder ((module Builder), builder) = t.builder in
   Builder.build builder context spec
 

--- a/worker/obuilder_build.mli
+++ b/worker/obuilder_build.mli
@@ -12,6 +12,7 @@ val build : t ->
   switch:Lwt_switch.t ->
   log:Log_data.t ->
   spec:Obuilder.Spec.t ->
-  src_dir:string -> (string, [ `Cancelled | `Msg of string ]) Lwt_result.t
+  src_dir:string ->
+  secrets:(string * string) list -> (string, [ `Cancelled | `Msg of string ]) Lwt_result.t
 
 val healthcheck : t -> (unit, [> `Msg of string]) Lwt_result.t


### PR DESCRIPTION
Secrets are a way to transmit sensitive key-value pairs to workers, without having them displayed in any log files. This PR adds a new `secrets` option to provide secret values from a client to a worker. They can be consumed by the job spec, either using the docker syntax or the obuilder syntax.

This depends on https://github.com/ocurrent/obuilder/pull/63