### PR TITLE
Fix opam constraint on digestif

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -42,7 +42,7 @@ The scheduler tries to schedule similar builds on the same machine, to benefit f
   logs
   fmt
   (conf-libev (<> :os "win32"))
-  digestif
+  (digestif (>= 0.8))
   fpath
   lwt-dllist
   (prometheus-app (>= 1.0))

--- a/ocluster.opam
+++ b/ocluster.opam
@@ -28,7 +28,7 @@ depends: [
   "logs"
   "fmt"
   "conf-libev" {os != "win32"}
-  "digestif"
+  "digestif" {>= "0.8"}
   "fpath"
   "lwt-dllist"
   "prometheus-app" {>= "1.0"}


### PR DESCRIPTION
API changed in 0.6 and 0.7 doesn't link. I'll forward this to opam-repository later