### PR TITLE
Allow pausing/unpausing/forgetting unconnected workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ it will continue with any jobs it is already running. Use `unpause` to resume it
 
 Instead of specifying a worker, you can also use `--all` to pause or unpause all workers in a pool.
 
+If you want to set the state of a worker that hasn't ever connected to the scheduler, use `--auto-create`.
+
 To update all workers in a pool:
 
 ```
@@ -267,6 +269,12 @@ Note that the worker just exits, assuming a service manager will restart it. If 
 you'll need to restart the worker yourself at this point.
 
 You can also give the name of a worker as an extra argument to update just that worker.
+
+To forget about an old worker (so that it no longer shows up under `disconnected:` in the state display:
+
+```
+ocluster-admin -c ./capnp-secrets/admin.cap forget linux-x86_64 my-host
+```
 
 ### Fair queuing
 

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -138,21 +138,32 @@ interface Submission {
 }
 
 struct WorkerInfo {
-  name   @0 :Text;
-  active @1 :Bool;
+  name      @0 :Text;
+  active    @1 :Bool;
+  connected @2 :Bool;
 }
 
 interface PoolAdmin {
   show      @0 () -> (state :Text);
   workers   @1 () -> (workers : List(WorkerInfo));
   worker    @3 (worker :Text) -> (worker :Worker);
-  setActive @2 (worker :Text, active :Bool) -> ();
+
+  setActive @2 (worker :Text, active :Bool, autoCreate :Bool) -> ();
+  # Mark worker as active or paused.
+  # This active flag is independent of the Queue.setActive one
+  # (the worker is paused if either the admin or the worker sets it inactive).
+  # This can be used even when the worker is disconnected.
+  # If autoCreate is true then this can be used even with an unknown worker,
+  # which may be useful if you want a new worker to start paused, for example.
 
   update    @4 (worker :Text) -> ();
   # Drain worker, ask it to restart with the latest version, and return when it comes back.
 
   setRate   @5 (id :Text, rate :Float64) -> ();
   # Set the expected share of the pool for this client.
+
+  forget    @6 (worker :Text) -> ();
+  # Remove worker from the set of known workers.
 }
 
 interface Admin {

--- a/scheduler/pool.ml
+++ b/scheduler/pool.ml
@@ -78,7 +78,10 @@ module Dao = struct
     get_rate : Sqlite3.stmt;
     set_rate : Sqlite3.stmt;
     remove_user : Sqlite3.stmt;
+    worker_known : Sqlite3.stmt;
+    known_workers : Sqlite3.stmt;
     ensure_worker : Sqlite3.stmt;
+    forget_worker : Sqlite3.stmt;
     set_paused : Sqlite3.stmt;
     get_paused : Sqlite3.stmt;
   }
@@ -116,8 +119,23 @@ module Dao = struct
       )
     |> Option.value ~default:1.0
 
+  let known_workers t ~pool =
+    Db.query t.known_workers Sqlite3.Data.[ TEXT pool ] |> List.map @@ function
+    | Sqlite3.Data.[ TEXT worker; INT 1L ] -> worker, true
+    | Sqlite3.Data.[ TEXT worker; INT 0L ] -> worker, false
+    | row -> Fmt.failwith "Bad row from DB: %a" Db.dump_row row
+
+  let worker_known t ~pool worker =
+    match Db.query_one t.worker_known Sqlite3.Data.[ TEXT pool; TEXT worker ] with
+    | Sqlite3.Data.[ INT 1L ] -> true
+    | Sqlite3.Data.[ INT 0L ] -> false
+    | row -> Fmt.failwith "Bad row from DB: %a" Db.dump_row row
+
   let ensure_worker t ~pool worker =
     Db.exec t.ensure_worker Sqlite3.Data.[ TEXT pool; TEXT worker ]
+
+  let forget_worker t ~pool worker =
+    Db.exec t.forget_worker Sqlite3.Data.[ TEXT pool; TEXT worker ]
 
   let set_paused t ~pool ~worker v =
     let v = Bool.to_int v |> Int64.of_int in
@@ -152,10 +170,14 @@ module Dao = struct
     let set_rate = Sqlite3.prepare db "INSERT OR REPLACE INTO pool_user_rate (pool, user, rate) VALUES (?, ?, ?)" in
     let get_rate = Sqlite3.prepare db "SELECT rate FROM pool_user_rate WHERE pool = ? AND user = ?" in
     let remove_user = Sqlite3.prepare db "DELETE FROM pool_user_rate WHERE pool = ? AND user = ?" in
+    let known_workers = Sqlite3.prepare db "SELECT id, paused FROM workers WHERE pool = ?" in
+    let worker_known = Sqlite3.prepare db "SELECT EXISTS (SELECT 1 FROM workers WHERE pool = ? AND id = ?)" in
     let ensure_worker = Sqlite3.prepare db "INSERT OR IGNORE INTO workers (pool, id) VALUES (?, ?)" in
+    let forget_worker = Sqlite3.prepare db "DELETE FROM workers WHERE pool = ? AND id = ?" in
     let set_paused = Sqlite3.prepare db "UPDATE workers SET paused = ? WHERE pool = ? AND id = ?" in
     let get_paused = Sqlite3.prepare db "SELECT paused FROM workers WHERE pool = ? AND id = ?" in
-    { query_cache; mark_cached; dump_cache; set_rate; get_rate; remove_user; ensure_worker; set_paused; get_paused }
+    { query_cache; mark_cached; dump_cache; set_rate; get_rate; remove_user;
+      known_workers; worker_known; ensure_worker; forget_worker; set_paused; get_paused }
 end
 
 let (let<>) x f =
@@ -169,7 +191,7 @@ let pp_rough_duration f x =
     Fmt.pf f "%.0fm" (x /. 60.)
 
 module Make (Item : S.ITEM)(Time : S.TIME) = struct
-  module Worker_map = Astring.String.Map
+  module Worker_map = Map.Make(String)
 
   type ticket = {
     key : < >;
@@ -557,6 +579,25 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
 
   let connected_workers t = t.workers
 
+  let with_worker t name f =
+    match register t ~name ~capacity:0 with
+    | Error `Name_taken -> f (Worker_map.find name t.workers)
+    | Ok w ->
+      Fun.protect (fun () -> f w)
+        ~finally:(fun () -> release w)
+
+  let worker_known t name =
+    Dao.worker_known t.db ~pool:t.pool name
+
+  let forget_worker t name =
+    if worker_known t name then (
+      if Worker_map.mem name t.workers then Error `Still_connected
+      else (
+        Dao.forget_worker t.db ~pool:t.pool name;
+        Ok ()
+      )
+    ) else Error `Unknown_worker
+
   let inactive_reasons worker =
     match worker.state with
     | `Running _ -> Inactive_reasons.empty
@@ -565,6 +606,17 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
 
   let is_active worker =
     inactive_reasons worker = Inactive_reasons.empty
+
+  let known_workers t =
+    Dao.known_workers t.db ~pool:t.pool
+    |> List.map (fun (name, paused) ->
+        let connected, active =
+          match Worker_map.find_opt name t.workers with
+          | None -> false, not paused
+          | Some w -> true, is_active w
+        in
+        { Cluster_api.Pool_admin.name; active; connected }
+      )
 
   let create ~name ~db =
     {
@@ -600,6 +652,13 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
     Worker_map.bindings x
     |> Fmt.(list ~sep:nop) pp_item f
 
+  let dump_disconnected =
+    let pp_item f (id, paused) =
+      Fmt.pf f "@,%s" id;
+      if paused then Fmt.string f " (paused)"
+    in
+    Fmt.(list ~sep:nop) pp_item
+
   let dump_main f = function
     | `Backlog (q : Backlog.t) ->
       Fmt.pf f "(backlog) %a" Backlog.dump q
@@ -621,11 +680,19 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
     let now = Time.gettimeofday () in
     Fmt.(seq ~sep:sp (dump_client t ~now)) f (Client_map.to_seq clients)
 
-  let pp_common f ({pool = _; db = _; main; clients; workers; cluster_capacity; pending_cached = _} as t) =
-    Fmt.pf f "capacity: %.0f@,queue: @[%a@]@,@[<v2>registered:%a@]@,clients: @[<hov>%a@]"
+  let pp_common f ({pool; db; main; clients; workers; cluster_capacity; pending_cached = _} as t) =
+    let disconnected =
+      Dao.known_workers db ~pool
+      |> List.filter_map (fun (name, paused) ->
+          if Worker_map.mem name workers then None
+          else Some (name, paused)
+        )
+    in
+    Fmt.pf f "capacity: %.0f@,queue: @[%a@]@,@[<v2>registered:%a@]@,@[<v2>disconnected:%a@]@,clients: @[<hov>%a@]"
       cluster_capacity
       dump_main main
       dump_workers workers
+      dump_disconnected disconnected
       (dump_clients t) clients
 
   let show f t =

--- a/test/test_scheduling.ml
+++ b/test/test_scheduling.ml
@@ -129,6 +129,7 @@ let%expect_test "cached_scheduling" =
     registered:
       worker-1 (0): []
       worker-2 (0): []
+    disconnected:
     clients:
     cached:
   |}];
@@ -147,6 +148,7 @@ let%expect_test "cached_scheduling" =
     registered:
       worker-1 (10): [u1:job1@0s(10)]
       worker-2 (10): [u1:job2@5s(10)]
+    disconnected:
     clients: u1(2)+17s
     cached: a: [worker-1], b: [worker-2]
   |}];
@@ -159,6 +161,7 @@ let%expect_test "cached_scheduling" =
     registered:
       worker-1 (0): []
       worker-2 (0): []
+    disconnected:
     clients: u1(2)+17s
     cached: a: [worker-1], b: [worker-2]
   |}];
@@ -178,6 +181,7 @@ let%expect_test "cached_scheduling" =
     registered:
       worker-1 (4): [u1:job4@11s(2) u1:job3@10s(2)]
       worker-2 (0): []
+    disconnected:
     clients: u1(2)+17s
     cached: a: [worker-1], b: [worker-2], c: [worker-2]
   |}];
@@ -199,6 +203,8 @@ let%expect_test "cached_scheduling" =
     queue: (backlog) [u1:job4@11s]
     registered:
       worker-2 (0): []
+    disconnected:
+      worker-1
     clients: u1(2)+17s
     cached: a: [worker-1; worker-2], b: [worker-2], c: [worker-2]
   |}];
@@ -217,6 +223,9 @@ let%expect_test "cached_scheduling" =
     capacity: 0
     queue: (backlog) []
     registered:
+    disconnected:
+      worker-1
+      worker-2
     clients: u1(2)
     cached: a: [worker-1; worker-2], b: [worker-2], c: [worker-2]
   |}];
@@ -252,6 +261,7 @@ let%expect_test "unbalanced" =
       worker-1 (12): [u1:job7@10s(2) u1:job6@9s(2) u1:job5@8s(2) u1:job4@7s(2)
                       u1:job3@6s(2) u1:job2@5s(2)]
       worker-2 (0): []
+    disconnected:
     clients: u1(2)+12s
     cached: a: [worker-1; worker-2]
   |}];
@@ -287,6 +297,8 @@ let%expect_test "no_workers" =
     capacity: 0
     queue: (backlog) [u1:job2@10s]
     registered:
+    disconnected:
+      worker-1
     clients: u1(1)+12s
     cached: a: [worker-1]
   |}];
@@ -361,6 +373,8 @@ let%expect_test "urgent" =
     queue: (backlog) [u1:job1@0s u1:job3@12s+urgent]
     registered:
       worker-2 (0): []
+    disconnected:
+      worker-1
     clients: u1(1)+24s
     cached: a: [worker-1], b: [worker-2]
   |}];
@@ -403,6 +417,7 @@ let%expect_test "urgent_worker" =
     registered:
       worker-1 (2): [u1:job2@10s(2)]
       worker-2 (0): []
+    disconnected:
     clients: u1(1)+22s
     cached: a: [worker-1], b: [worker-2]
   |}];
@@ -422,6 +437,7 @@ let%expect_test "urgent_worker" =
     registered:
       worker-1 (6): [u1:job2@10s(2) u1:job6@24s(2+urgent) u1:job4@22s(2+urgent)]
       worker-2 (0): []
+    disconnected:
     clients: u1(2)+25s
     cached: a: [worker-1], b: [worker-2]
   |}];
@@ -454,6 +470,7 @@ let%expect_test "inactive" =
     registered:
       worker-1 (2): [u1:job2@10s(2)]
       worker-2 (0): []
+    disconnected:
     clients: u1(1)+12s
     cached: a: [worker-1]
   |}];
@@ -467,6 +484,7 @@ let%expect_test "inactive" =
     registered:
       worker-1 (0): (inactive: worker pause)
       worker-2 (10): [u1:job2@10s(10)]
+    disconnected:
     clients: u1(1)+12s
     cached: a: [worker-1; worker-2]
   |}];
@@ -489,6 +507,7 @@ let%expect_test "inactive" =
     registered:
       worker-1 (0): (inactive: worker pause)
       worker-2 (0): (inactive: worker pause)
+    disconnected:
     clients: u1(2)+13s
     cached: a: [worker-1; worker-2]
   |}];
@@ -525,6 +544,7 @@ let%expect_test "cancel_worker_queue" =
     registered:
       worker-1 (4): [u1:job3@6s(2) u1:job2@5s(2)]
       worker-2 (0): []
+    disconnected:
     clients: u1(2)+12s
     cached: a: [worker-1], b: [worker-2]
   |}];
@@ -539,6 +559,7 @@ let%expect_test "cancel_worker_queue" =
     registered:
       worker-1 (2): [u1:job3@6s(2)]
       worker-2 (0): []
+    disconnected:
     clients: u1(2)+12s
     cached: a: [worker-1], b: [worker-2]
   |}];
@@ -551,6 +572,8 @@ let%expect_test "cancel_worker_queue" =
     queue: (backlog) [u1:job3@6s]
     registered:
       worker-1 (0): (inactive: worker pause)
+    disconnected:
+      worker-2
     clients: u1(2)+12s
     cached: a: [worker-1], b: [worker-2]
   |}];
@@ -564,6 +587,9 @@ let%expect_test "cancel_worker_queue" =
     capacity: 0
     queue: (backlog) []
     registered:
+    disconnected:
+      worker-1
+      worker-2
     clients: u1(2)+12s
     cached: a: [worker-1], b: [worker-2]
   |}];
@@ -600,6 +626,7 @@ let%expect_test "push_back" =
     registered:
       worker-1 (4): [u1:job3@6s(2) u1:job2@5s(2)]
       worker-2 (0): []
+    disconnected:
     clients: u1(2)+7s
     cached: a: [worker-1]
   |}];
@@ -612,6 +639,8 @@ let%expect_test "push_back" =
     queue: (backlog) [u1:job3@6s u1:job2@5s]
     registered:
       worker-1 (0): (inactive: worker pause)
+    disconnected:
+      worker-2
     clients: u1(2)+7s
     cached: a: [worker-1]
   |}];
@@ -659,6 +688,7 @@ let%expect_test "fairness" =
     registered:
       worker-1 (0): []
       worker-2 (0): []
+    disconnected:
     clients: alice(2)+15s bob(2)+15s
     cached: : [worker-1; worker-2]
   |}];
@@ -710,6 +740,7 @@ let%expect_test "fairness_rates" =
     registered:
       worker-1 (0): []
       worker-2 (0): []
+    disconnected:
     clients: alice(5)+6s bob(1)+30s
     cached: : [worker-1; worker-2]
   |}];
@@ -734,6 +765,7 @@ let%expect_test "inactive" =
     queue: (backlog) []
     registered:
       worker-1 (0): (inactive: worker pause)
+    disconnected:
     clients:
     cached: |}];
   (* Now also paused by admin: *)
@@ -744,6 +776,7 @@ let%expect_test "inactive" =
     queue: (backlog) []
     registered:
       worker-1 (0): (inactive: worker pause, admin pause)
+    disconnected:
     clients:
     cached: |}];
   (* Worker unpauses, but is still inactive: *)
@@ -754,6 +787,7 @@ let%expect_test "inactive" =
     queue: (backlog) []
     registered:
       worker-1 (0): (inactive: admin pause)
+    disconnected:
     clients:
     cached: |}];
   (* Admin also unpauses: *)
@@ -764,6 +798,7 @@ let%expect_test "inactive" =
     queue: (backlog) []
     registered:
       worker-1 (0): []
+    disconnected:
     clients:
     cached: |}];
   (* Shutdown: *)
@@ -774,6 +809,7 @@ let%expect_test "inactive" =
     queue: (backlog) []
     registered:
       worker-1 (0): (inactive: shutting down)
+    disconnected:
     clients:
     cached: |}];
   Lwt.return_unit
@@ -793,6 +829,7 @@ let%expect_test "persist_pause" =
     queue: (backlog) []
     registered:
       worker-1 (0): (inactive: worker pause, admin pause, shutting down)
+    disconnected:
     clients:
     cached: |}];
   (* The worker unpauses itself, but this will not persist: *)
@@ -806,6 +843,7 @@ let%expect_test "persist_pause" =
     queue: (backlog) []
     registered:
       worker-1 (0): (inactive: worker pause, admin pause)
+    disconnected:
     clients:
     cached: |}];
   (* The admin unpauses it: *)
@@ -820,6 +858,38 @@ let%expect_test "persist_pause" =
     queue: (backlog) []
     registered:
       worker-1 (0): []
+    disconnected:
     clients:
     cached: |}];
+  Pool.release w1;
+  Lwt.return_unit
+
+let pp_forget =
+  let pp_forget_error f = function
+    | `Still_connected -> Fmt.string f "still connected"
+    | `Unknown_worker -> Fmt.string f "unknown worker"
+  in
+  Fmt.(result ~ok:(const string "ok")) ~error:pp_forget_error
+
+(* Forgetting workers. *)
+let%expect_test "forget" =
+  with_test_db @@ fun db ->
+  let pool = Pool.create ~db ~name:"simple" in
+  let w1 = Pool.register pool ~name:"worker-1" ~capacity:1 |> Result.get_ok in
+  println "%a" pp_forget @@ Pool.forget_worker pool "worker-1";
+  [%expect{| still connected |}];
+  Pool.release w1;
+  println "%a" pp_forget @@ Pool.forget_worker pool "worker-1";
+  [%expect{| ok |}];
+  println "%a" pp_forget @@ Pool.forget_worker pool "worker-1";
+  [%expect{| unknown worker |}];
+  print_pool pool;
+  [%expect{|
+    capacity: 0
+    queue: (backlog) []
+    registered:
+    disconnected:
+    clients:
+    cached:
+    |}];
   Lwt.return_unit


### PR DESCRIPTION
- `pause`/`unpause` now works even when the worker is disconnected.
- `pause`/`unpause` get a new `--auto-create` flag, which adds the worker to the known list. This is useful in deployment scripts where you need to ensure a worker is paused in order to perform some upgrade step, but the worker might not exist yet.
- `state` now also lists disconnected workers and their states.
- `forget` can be used to forget about a worker.

