### PR TITLE
API to wait for a worker to drain

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ ocluster-admin -c ./capnp-secrets/admin.cap pause linux-x86_64 my-host
 A paused worker will not be assigned any more items until it is unpaused, but
 it will continue with any jobs it is already running. Use `unpause` to resume it.
 
+Use `pause --wait` if you want to wait until all running jobs have finished.
+
 Instead of specifying a worker, you can also use `--all` to pause or unpause all workers in a pool.
 
 If you want to set the state of a worker that hasn't ever connected to the scheduler, use `--auto-create`.

--- a/api/progress.ml
+++ b/api/progress.ml
@@ -1,0 +1,24 @@
+open Capnp_rpc_lwt
+
+let local fn =
+  let module X = Raw.Service.Progress in
+  X.local @@ object
+    inherit X.service
+
+    method report_impl params release_param_caps =
+      let open X.Report in
+      let msg = Params.status_get params in
+      release_param_caps ();
+      fn msg;
+      Service.return_empty ()
+  end
+
+module X = Raw.Client.Progress
+
+type t = X.t Capability.t
+
+let report t msg =
+  let open X.Report in
+  let request, params = Capability.Request.create Params.init_pointer in
+  Params.status_set params msg;
+  Capability.call_for_unit t method_id request

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -143,6 +143,12 @@ struct WorkerInfo {
   connected @2 :Bool;
 }
 
+# A callback for receiving progress updates.
+interface Progress {
+  report @0 (status :Text) -> ();
+  # Called when the status changes.
+}
+
 interface PoolAdmin {
   show      @0 () -> (state :Text);
   workers   @1 () -> (workers : List(WorkerInfo));
@@ -156,8 +162,14 @@ interface PoolAdmin {
   # If autoCreate is true then this can be used even with an unknown worker,
   # which may be useful if you want a new worker to start paused, for example.
 
-  update    @4 (worker :Text) -> ();
+  drain     @7 (worker :Text, progress :Progress) -> ();
+  # Mark the worker as paused and wait until no jobs are running.
+  # Returns immediately if the worker isn't connected.
+  # If given, [progress] receives one-line progress reports.
+
+  update    @4 (worker :Text, progress :Progress) -> ();
   # Drain worker, ask it to restart with the latest version, and return when it comes back.
+  # If given, [progress] receives one-line progress reports.
 
   setRate   @5 (id :Text, rate :Float64) -> ();
   # Set the expected share of the pool for this client.

--- a/scheduler/cluster_scheduler.ml
+++ b/scheduler/cluster_scheduler.ml
@@ -46,6 +46,16 @@ module Item = struct
     | x -> Fmt.string f x
 end
 
+let report_progress ?progress msg =
+  msg |> Fmt.kstr @@ fun msg ->
+  match progress with
+  | None -> Lwt.return_unit
+  | Some progress ->
+    Cluster_api.Progress.report progress msg >|= function
+    | Ok () -> ()
+    | Error (`Capnp ex) ->
+      Logs.info (fun f -> f "Failed to send progress report (%s): %a" msg Capnp_rpc.Error.pp ex)
+
 module Pool_api = struct
   module Inactive_reasons = Pool.Inactive_reasons
   module Pool = Pool.Make(Item)(Unix)
@@ -148,14 +158,47 @@ module Pool_api = struct
       | Error `Still_connected -> Service.fail "Worker %S is still connected!" name
       | Error `Unknown_worker -> Service.fail "Worker %S not known in this pool" name
     in
-    let update name =
+    let drain ?progress name =
       match Pool.Worker_map.find_opt name (Pool.connected_workers t.pool) with
-      | None -> Service.fail "Unknown worker"
+      | None ->
+        if Pool.worker_known t.pool name then (
+          (* Disconnected, so already drained. Just make sure it will be paused on reconnect. *)
+          Pool.with_worker t.pool name (fun worker ->
+              Pool.set_active worker false ~reason:Inactive_reasons.admin_pause;
+            );
+          report_progress ?progress "Disconnected (nothing to drain)" >>= fun () ->
+          Lwt_result.return (Service.Response.create_empty ())
+        ) else Lwt_result.fail (`Capnp (Capnp_rpc.Error.exn "Unknown worker"))
+      | Some w ->
+        (* Drain a connected worker. *)
+        Pool.set_active w false ~reason:Inactive_reasons.admin_pause;
+        let rec aux prev =
+          report_progress ?progress "Running jobs: %d" prev >>= fun () ->
+          if prev = 0 then Lwt_result.return (Service.Response.create_empty ())
+          else (
+            Pool.running_jobs w ~prev >>= aux
+          )
+        in
+        Pool.running_jobs w >>= aux
+    in
+    let update ?progress name =
+      match Pool.Worker_map.find_opt name (Pool.connected_workers t.pool) with
+      | None -> Lwt_result.fail (`Capnp (Capnp_rpc.Error.exn "Unknown worker"))
       | Some w ->
         let cap = Option.get (worker t name) in
         Pool.shutdown w;        (* Prevent any new items being assigned to it. *)
-        Service.return_lwt @@ fun () ->
         Capability.with_ref cap @@ fun worker ->
+        let rec aux prev =
+          if prev = 0 then Lwt.return ()
+          else (
+            report_progress ?progress "Running jobs: %d" prev >>= fun () ->
+            Pool.running_jobs w ~prev >>= aux
+          )
+        in
+        (* Drain worker (with progress updates) *)
+        Pool.running_jobs w >>= aux >>= fun () ->
+        (* Restart *)
+        report_progress ?progress "Restarting" >>= fun () ->
         Log.info (fun f -> f "Restarting %S" name);
         Cluster_api.Worker.self_update worker >>= function
         | Error _ as e -> Lwt.return e
@@ -179,7 +222,7 @@ module Pool_api = struct
         Ok ()
       ) else Error `No_such_user
     in
-    Cluster_api.Pool_admin.local ~show ~workers ~worker:(worker t) ~set_active ~update ~forget ~set_rate
+    Cluster_api.Pool_admin.local ~show ~workers ~worker:(worker t) ~set_active ~update ~drain ~forget ~set_rate
 
   let remove_client t ~client_id =
     Pool.remove_client t.pool ~client_id

--- a/scheduler/cluster_scheduler.ml
+++ b/scheduler/cluster_scheduler.ml
@@ -94,6 +94,7 @@ module Pool_api = struct
     | Ok { set_job; descr } ->
       Capability.inc_ref job;
       Capability.resolve_ok set_job job;
+      Lwt.on_termination (Cluster_api.Job.result job) (fun () -> Pool.job_finished q);
       Ok descr
 
   let register t ~name ~capacity worker =

--- a/scheduler/pool.ml
+++ b/scheduler/pool.ml
@@ -307,6 +307,7 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
                     | `Inactive of Inactive_reasons.t * unit Lwt.t * unit Lwt.u  (* ready/set_ready for resume *)
                     | `Finished ];
     mutable workload : int;     (* Total cost of items in worker's queue. *)
+    mutable running : int;      (* Number of jobs currently running. *)
   } and client_info = {
     id : string;
     mutable next_fair_start_time : float;
@@ -400,6 +401,7 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
           let item = ticket.item in
           Log.info (fun f -> f "%S takes %a from its local queue" worker.name Item.pp item);
           mark_cached ticket.item worker;
+          worker.running <- worker.running + 1;
           Prometheus.Counter.inc_one (Metrics.jobs_accepted t.pool);
           dec_pending_count t ticket;
           Lwt_result.return ticket.item
@@ -427,12 +429,17 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
                 let item = ticket.item in
                 Log.info (fun f -> f "%S takes %a from the main queue" worker.name Item.pp item);
                 mark_cached item worker;
+                worker.running <- worker.running + 1;
                 Prometheus.Counter.inc_one (Metrics.jobs_accepted t.pool);
                 dec_pending_count t ticket;
                 Lwt_result.return item
               )
     in
     aux ()
+
+  let job_finished worker =
+    Log.debug (fun f -> f "%S finishes a job" worker.name);
+    worker.running <- worker.running - 1
 
   (* Worker is leaving and system is backlogged. Move the worker's items to the backlog. *)
   let rec push_back worker worker_q q =
@@ -461,6 +468,7 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
         name;
         state = `Inactive (inactive_reasons, ready, set_ready);
         workload = 0;
+        running = 0;
         capacity;
       } in
       t.workers <- Worker_map.add name q t.workers;
@@ -648,7 +656,7 @@ module Make (Item : S.ITEM)(Time : S.TIME) = struct
 
   let dump_workers f x =
     let pp_item f (id, w) =
-      Fmt.pf f "@,%s (%d): @[%a@]" id w.workload pp_state w in
+      Fmt.pf f "@,%s (%d): @[%a@] (%d running)" id w.workload pp_state w w.running in
     Worker_map.bindings x
     |> Fmt.(list ~sep:nop) pp_item f
 

--- a/scheduler/pool.mli
+++ b/scheduler/pool.mli
@@ -85,6 +85,10 @@ module Make (Item : S.ITEM) (Time : S.TIME) : sig
   val job_finished : worker -> unit
   (** [job_finished worker] is called when [worker] completes a job. *)
 
+  val running_jobs : ?prev:int -> worker -> int Lwt.t
+  (** [running_jobs worker] returns the number of jobs running on [worker].
+      @param prev Wait until the number is different to [prev] before returning. *)
+
   val set_active : reason:Inactive_reasons.t -> worker -> bool -> unit
   (** [set_active ~reason worker active] sets the worker's active flag for [reason].
       A worker is active if it has no reasons to be inactive.

--- a/scheduler/pool.mli
+++ b/scheduler/pool.mli
@@ -82,6 +82,9 @@ module Make (Item : S.ITEM) (Time : S.TIME) : sig
   val pop : worker -> (Item.t, [> `Finished]) Lwt_result.t
   (** [pop worker] gets the next item for [worker]. *)
 
+  val job_finished : worker -> unit
+  (** [job_finished worker] is called when [worker] completes a job. *)
+
   val set_active : reason:Inactive_reasons.t -> worker -> bool -> unit
   (** [set_active ~reason worker active] sets the worker's active flag for [reason].
       A worker is active if it has no reasons to be inactive.


### PR DESCRIPTION
- The scheduler now keeps track of how many jobs each worker is running.
- The number of jobs is shown in the pool status.
- The pool admin API has a drain operation, which pauses the worker and waits for the number of jobs to reach zero.
- The admin CLI allows `pause --wait` to use this.
- The scheduler reports progress back to the client.
- The `update` command also now shows draining progress.

This is useful for scripts that need to wait for a worker to stop before continuing (e.g. when upgrading a build machine).