### PR TITLE
Add ca-certificates to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN opam config exec -- dune build \
 
 FROM debian:10
 RUN apt-get update && apt-get install libev4 libsqlite3-0 -y --no-install-recommends
+RUN apt-get install ca-certificates -y  # https://github.com/mirage/ocaml-conduit/issues/388
 WORKDIR /var/lib/ocluster-scheduler
 ENTRYPOINT ["/usr/local/bin/ocluster-scheduler"]
 COPY --from=build \

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ The `scheduler` service also writes out `./capnp-secrets/stress-admin.cap`, whic
 For example:
 
 ```
-dune exec -- ocluster-admin show ./capnp-secrets/stress-admin.cap linux-x86_64
+dune exec -- ocluster-admin show -c ./capnp-secrets/stress-admin.cap linux-x86_64
 ```
 
 You can also create your own client endpoints and submit your own jobs, in addition to those submitted by the testbed itself.

--- a/stress/Dockerfile
+++ b/stress/Dockerfile
@@ -1,2 +1,3 @@
 FROM debian:10
 RUN apt-get update && apt-get install libev4 libsqlite3-0 -y --no-install-recommends
+RUN apt-get install ca-certificates -y  # https://github.com/mirage/ocaml-conduit/issues/388


### PR DESCRIPTION
This is a work-around for https://github.com/mirage/ocaml-conduit/issues/388