### PR TITLE
Windows support

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -2,5 +2,8 @@
  (public_names ocluster-scheduler ocluster-client ocluster-worker ocluster-admin)
  (package ocluster)
  (names scheduler client worker admin)
- (libraries dune-build-info ocluster-api logs.cli logs.fmt fmt.cli fmt.tty capnp-rpc-unix cluster_scheduler cluster_worker prometheus-app.unix db))
+ (libraries dune-build-info ocluster-api logs.cli logs.fmt fmt.cli fmt.tty capnp-rpc-unix cluster_scheduler cluster_worker prometheus-app.unix db
+  (select winsvc_wrapper.ml from
+   (winsvc -> winsvc_wrapper.winsvc.ml)
+   (       -> winsvc_wrapper..ml))))
 

--- a/bin/scheduler.ml
+++ b/bin/scheduler.ml
@@ -4,8 +4,8 @@ module Restorer = Capnp_rpc_net.Restorer
 
 let ( / ) = Filename.concat
 
-let setup_log default_level =
-  Prometheus_unix.Logging.init ?default_level ();
+let setup_log ?(formatter=Format.err_formatter) default_level =
+  Prometheus_unix.Logging.init ~formatter ?default_level ();
   ()
 
 let or_die = function
@@ -85,7 +85,8 @@ let provision_client ~admin ~secrets_dir id =
     Logs.app (fun f -> f "Wrote capability reference to %S" path)
   )
 
-let main () capnp secrets_dir pools prometheus_config state_dir default_clients =
+let main default_level ?formatter capnp secrets_dir pools prometheus_config state_dir default_clients =
+  setup_log ?formatter default_level;
   if not (dir_exists state_dir) then Unix.mkdir state_dir 0o755;
   let db = Sqlite3.db_open (state_dir / "scheduler.db") in
   Sqlite3.busy_timeout db 1000;
@@ -121,6 +122,14 @@ let main () capnp secrets_dir pools prometheus_config state_dir default_clients 
   end
 
 (* Command-line parsing *)
+
+let main ~install (default_level, args1) ((capnp, secrets_dir, pools, prometheus_config, state_dir, default_clients), args2) =
+  let (name, display, text) = ("ocluster-scheduler", "OCluster Scheduler", "Manage build workers") in
+  if install then
+    `Ok (Winsvc_wrapper.install name display text (args1 @args2))
+  else
+    `Ok (Winsvc_wrapper.run name state_dir (fun ?formatter () ->
+             main default_level ?formatter capnp secrets_dir pools prometheus_config state_dir default_clients))
 
 open Cmdliner
 
@@ -172,12 +181,32 @@ let default_clients =
     ~docv:"NAME"
     ["default-clients"]
 
-let setup_log =
-  Term.(const setup_log $ Logs_cli.level ())
+let scheduler_opts_t =
+  let scheduler_opts capnp secrets_dir pools prometheus_config state_dir default_clients  =
+    (capnp, secrets_dir, pools, prometheus_config, state_dir, default_clients) in
+  Term.(with_used_args
+    (const scheduler_opts $ Capnp_rpc_unix.Vat_config.cmd $ secrets_dir $ pools
+     $ listen_prometheus $ state_dir $ default_clients))
 
-let cmd =
+let cmd ~install =
   let doc = "Manage build workers" in
-  Term.(const main $ setup_log $ Capnp_rpc_unix.Vat_config.cmd $ secrets_dir $ pools $ listen_prometheus $ state_dir $ default_clients),
-  Term.info "ocluster-scheduler" ~doc ~version:Version.t
+  let man = [
+    `P "On $(b,Windows), specify '$(b,install)' as the first \
+        command-line paramater to install the scheduler as a Windows \
+        service with the specified parameters, and '$(b,remove)' to \
+        remove the scheduler from the services." ] in
+  Term.(ret (const (main ~install) $ with_used_args (Logs_cli.level ()) $ scheduler_opts_t)),
+  Term.info "ocluster-scheduler" ~doc ~man ~version:Version.t
 
-let () = Term.(exit @@ eval cmd)
+let () =
+  match Array.to_list Sys.argv with
+  | hd :: "install" :: argv ->
+    Term.(exit @@ eval ~argv:(Array.of_list (hd :: argv)) (cmd ~install:true))
+  | _ :: "remove" :: args ->
+    if args <> [] then begin
+      prerr_endline "'remove' should be used only once, in first position.";
+      exit 1
+    end else
+      Winsvc_wrapper.remove "ocluster-scheduler"
+  | _ ->
+    Term.(exit @@ eval (cmd ~install:false))

--- a/bin/winsvc_wrapper..ml
+++ b/bin/winsvc_wrapper..ml
@@ -1,0 +1,5 @@
+let run _name _state_dir (main:?formatter:Format.formatter -> unit -> unit) = main ()
+
+let install _name _display _text _arguments = failwith "Cannot install a service on non-Windows systems."
+
+let remove _name = failwith "Cannot remove a service on non-Windows systems."

--- a/bin/winsvc_wrapper.winsvc.ml
+++ b/bin/winsvc_wrapper.winsvc.ml
@@ -1,0 +1,51 @@
+let dir_exists d =
+  match Unix.lstat d with
+  | Unix.{ st_kind = S_DIR; _ } -> true
+  | _ -> false
+  | exception Unix.Unix_error(Unix.ENOENT, _, _) -> false
+
+let ensure_dir path =
+  if not (dir_exists path) then Unix.mkdir path 0o700
+
+let run name state_dir (main:?formatter:Format.formatter -> unit -> unit) =
+  let stop_notification = Lwt_unix.make_notification ~once:true (fun () -> exit 0) in
+  let module Svc = Winsvc.Make
+    (struct
+      let name = name
+      let display = ""
+      let text = ""
+      let arguments = []
+      let stop () = Lwt_unix.send_notification stop_notification
+    end)
+  in
+  try
+    let name = Printf.sprintf "%s-%d.log" (Sys.executable_name |> Filename.basename |> Filename.remove_extension) (Random.bits ()) in
+    let f = Filename.concat state_dir name in
+    ensure_dir state_dir;
+    let formatter = Format.formatter_of_out_channel (open_out_bin f) in
+    Svc.run (main ~formatter)
+  with Failure _ -> main ()
+
+let install name display text arguments =
+  let module Svc = Winsvc.Make
+    (struct
+      let name = name
+      let display = display
+      let text = text
+      let arguments = arguments
+      let stop () = ()
+    end)
+  in
+  Svc.install ()
+
+let remove name =
+  let module Svc = Winsvc.Make
+    (struct
+      let name = name
+      let display = ""
+      let text = ""
+      let arguments = []
+      let stop () = ()
+    end)
+  in
+  Svc.remove ()

--- a/dune-project
+++ b/dune-project
@@ -32,13 +32,14 @@
   capnp-rpc-net
   (capnp-rpc-unix (>= 1.2))
   (extunix (>= 0.3.2))
+  (winsvc (and (>= 1.0.1) (= :os "win32")))
   logs
   fmt
   (conf-libev (<> :os "win32"))
   (digestif (>= 0.8))
   fpath
   lwt-dllist
-  (prometheus-app (>= 1.0))
+  (prometheus-app (>= 1.1))
   cohttp-lwt-unix
   sqlite3
   obuilder

--- a/ocluster.opam
+++ b/ocluster.opam
@@ -27,13 +27,14 @@ depends: [
   "capnp-rpc-net"
   "capnp-rpc-unix" {>= "1.2"}
   "extunix" {>= "0.3.2"}
+  "winsvc" {>= "1.0.1" & os = "win32"}
   "logs"
   "fmt"
   "conf-libev" {os != "win32"}
   "digestif" {>= "0.8"}
   "fpath"
   "lwt-dllist"
-  "prometheus-app" {>= "1.0"}
+  "prometheus-app" {>= "1.1"}
   "cohttp-lwt-unix"
   "sqlite3"
   "obuilder"


### PR DESCRIPTION
This PR adds support for Windows.
The service interface uses subcommands (my current design, which I find simpler), but @dra27 prefers flags, but it's the end of the week and I've been fighting against cmdliner for too long, so here it is.
The Lwt_io bit is going to be fixed upstream.
Vendoring winvsc is required for bug fixes (a PR is opened).
ExtUnix dev branch has required fixes, so this requires extunix > 0.3.1 (unreleased at the time of writing).