### PR TITLE
Depend on more current_* modules to build examples

### DIFF
--- a/current_ocluster.opam
+++ b/current_ocluster.opam
@@ -14,6 +14,8 @@ depends: [
   "lwt"
   "current" {>= "0.3"}
   "current_git" {>= "0.3"}
+  "current_web" {>= "0.3" & with-test}
+  "current_github" {>= "0.3" & with-test}
   "capnp-rpc-unix" {>= "0.9.0"}
   "duration"
   "logs"

--- a/dune-project
+++ b/dune-project
@@ -58,6 +58,8 @@
   lwt
   (current (>= 0.3))
   (current_git (>= 0.3))
+  (current_web (and (>= 0.3) :with-test))
+  (current_github (and (>= 0.3) :with-test))
   (capnp-rpc-unix (>= 0.9.0))
   duration
   logs


### PR DESCRIPTION
The CI complains that the examples is using the current_web library,
but none of the packages declared depends on current_web. With a dummy
ocluster-examples package, the CI will install the required library.