### PR TITLE
Support Fmt.cli and Logs.cli

### DIFF
--- a/bin/client.ml
+++ b/bin/client.ml
@@ -1,9 +1,6 @@
 open Lwt.Infix
 open Capnp_rpc_lwt
 
-let () =
-  Logging.init ()
-
 let or_die = function
   | Ok x -> x
   | Error `Msg m -> failwith m
@@ -62,7 +59,7 @@ let read_whole_file path =
   let len = in_channel_length ic in
   really_input_string ic len
 
-let submit { submission_path; pool; repository; commits; cache_hint; urgent; secrets } spec =
+let submit () { submission_path; pool; repository; commits; cache_hint; urgent; secrets } spec =
   let src =
     match repository, commits with
     | None, [] -> None
@@ -268,7 +265,7 @@ let submit_docker_options =
 
 let submit_docker =
   let doc = "Submit a Docker build to the scheduler" in
-  Term.(const submit $ submit_options_common $ submit_docker_options),
+  Term.(const submit $ Logging.term $ submit_options_common $ submit_docker_options),
   Term.info "submit-docker" ~doc
 
 let submit_obuilder_options =
@@ -279,7 +276,7 @@ let submit_obuilder_options =
 
 let submit_obuilder =
   let doc = "Submit an OBuilder build to the scheduler" in
-  Term.(const submit $ submit_options_common $ submit_obuilder_options),
+  Term.(const submit $ Logging.term $ submit_options_common $ submit_obuilder_options),
   Term.info "submit-obuilder" ~doc
 
 let cmds = [submit_docker; submit_obuilder]

--- a/bin/dune
+++ b/bin/dune
@@ -2,4 +2,5 @@
  (public_names ocluster-scheduler ocluster-client ocluster-worker ocluster-admin)
  (package ocluster)
  (names scheduler client worker admin)
- (libraries dune-build-info ocluster-api logs.fmt fmt.tty capnp-rpc-unix cluster_scheduler cluster_worker prometheus-app.unix db))
+ (libraries dune-build-info ocluster-api logs.cli logs.fmt fmt.cli fmt.tty capnp-rpc-unix cluster_scheduler cluster_worker prometheus-app.unix db))
+

--- a/bin/logging.ml
+++ b/bin/logging.ml
@@ -16,8 +16,11 @@ let reporter =
   in
   { Logs.report = report }
 
-let init () =
-  Fmt_tty.setup_std_outputs ();
-  Logs.(set_level (Some Warning));
+let init style_renderer level =
+  Fmt_tty.setup_std_outputs ?style_renderer ();
+  Logs.set_level level;
   (* Logs.Src.set_level Capnp_rpc.Debug.src (Some Debug); *)
   Logs.set_reporter reporter
+
+let term =
+  Cmdliner.Term.(const init $ Fmt_cli.style_renderer () $ Logs_cli.level ())


### PR DESCRIPTION
The first commit is just a switch to `Cmdliner.Arg.&`, I find it cleaner and it's more in line with Cmdliner's documentation, but I can remove it if you prefer. (EDIT: removed).
The second introduces support for Fmt.cli, that's the `--color=always|never|auto flag`, and support for setting logs verbosity through the command line. This introduces a bit of noise in the help page, but helps development by not having to patch the source to get more logs. The new options are only available through sub-commands.
The scheduler and the worker don't use Fmt.cli as their logs are given to Prometheus.