### PR TITLE
Make free-space check work on Windows

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -31,6 +31,7 @@
   capnp-rpc-lwt
   capnp-rpc-net
   (capnp-rpc-unix (>= 1.2))
+  (extunix (>= 0.3.2))
   logs
   fmt
   (conf-libev (<> :os "win32"))

--- a/ocluster.opam
+++ b/ocluster.opam
@@ -26,6 +26,7 @@ depends: [
   "capnp-rpc-lwt"
   "capnp-rpc-net"
   "capnp-rpc-unix" {>= "1.2"}
+  "extunix" {>= "0.3.2"}
   "logs"
   "fmt"
   "conf-libev" {os != "win32"}

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -171,7 +171,8 @@ let check_docker_partition t =
   match t.prune_threshold with
   | None -> Lwt_result.return ()
   | Some prune_threshold ->
-    Df.free_space_percent "/var/lib/docker" >|= fun free ->
+    Lwt_process.pread_line("", [| "docker"; "info"; "-f"; "{{.DockerRootDir}}" |]) >>= fun line ->
+    Df.free_space_percent (String.trim line) >|= fun free ->
     Log.info (fun f -> f "Docker partition: %.0f%% free" free);
     if free < prune_threshold then Error `Disk_space_low
     else Ok ()

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -171,8 +171,8 @@ let check_docker_partition t =
   match t.prune_threshold with
   | None -> Lwt_result.return ()
   | Some prune_threshold ->
-    Lwt_process.pread_line("", [| "docker"; "info"; "-f"; "{{.DockerRootDir}}" |]) >>= fun line ->
-    Df.free_space_percent (String.trim line) >|= fun free ->
+    Lwt_process.pread_line("", [| "docker"; "info"; "-f"; "{{.DockerRootDir}}" |]) >|= fun line ->
+    let free = Df.free_space_percent (String.trim line) in
     Log.info (fun f -> f "Docker partition: %.0f%% free" free);
     if free < prune_threshold then Error `Disk_space_low
     else Ok ()

--- a/worker/df.ml
+++ b/worker/df.ml
@@ -1,13 +1,11 @@
-open Lwt.Infix
-
-let free_space_percent path =
-  Lwt_process.pread ("", [| "df"; path; "--output=pcent" |]) >|= fun lines ->
-  match String.split_on_char '\n' (String.trim lines) with
-  | [_; result] ->
-    let used =
-      try Scanf.sscanf result " %f%%" Fun.id
-      with _ -> Fmt.failwith "Expected %S, got %S" "xx%" result
-    in
-    100. -. used
-  | _ ->
-    Fmt.failwith "Expected two lines from df, but got:@,%S" lines
+let free_space_percent root_dir =
+  let root_dir =
+    if Sys.win32 then
+      let vol, _ = Fpath.(v root_dir |> split_volume) in
+      vol ^ "\\"
+    else
+      root_dir
+  in
+  let vfs = ExtUnix.All.statvfs root_dir in
+  let used = Int64.sub vfs.f_blocks vfs.f_bfree in
+  100. -. 100. *. (Int64.to_float used) /. (Int64.to_float (Int64.add used vfs.f_bavail))

--- a/worker/dune
+++ b/worker/dune
@@ -1,3 +1,3 @@
 (library
  (name cluster_worker)
- (libraries ocluster-api digestif fpath logs capnp-rpc-lwt lwt.unix prometheus-app cohttp-lwt-unix obuilder))
+ (libraries ocluster-api digestif fpath logs capnp-rpc-lwt lwt.unix prometheus-app cohttp-lwt-unix obuilder extunix))

--- a/worker/obuilder_build.ml
+++ b/worker/obuilder_build.ml
@@ -64,7 +64,7 @@ let do_prune ~path ~prune_threshold t =
     let stop = Unix.gettimeofday () -. prune_margin |> Unix.gmtime in
     let limit = 100 in
     Builder.prune builder ~before:stop limit >>= fun n ->
-    Df.free_space_percent path >>= fun free ->
+    let free = Df.free_space_percent path in
     Log.info (fun f -> f "OBuilder partition: %.0f%% free after pruning %d items" free n);
     if free > prune_threshold then Lwt.return_unit      (* Space problem is fixed! *)
     else if n < limit then (
@@ -92,7 +92,7 @@ let check_free_space t =
   | Some prune_threshold ->
     let path = store_path t in
     let rec aux () =
-      Df.free_space_percent path >>= fun free ->
+      let free = Df.free_space_percent path in
       Log.info (fun f -> f "OBuilder partition: %.0f%% free" free);
       (* If we're low on space, spawn a pruning thread. *)
       if free < prune_threshold && t.pruning = false then (


### PR DESCRIPTION
- Fetch docker root dir from docker info.
- Use extunix to get free space instead of shelling out to df.

Cherry-picked from #128.