### PR TITLE
Use --connect for the worker capability too

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ contains a secret token granting it access.
 To run the build service locally:
 
 ```
-ocluster-worker ./capnp-secrets/pool-linux-x86_64.cap \
+ocluster-worker \
+  --connect=./capnp-secrets/pool-linux-x86_64.cap \
   --state-dir=/var/lib/ocluster-worker \
   --name=my-host --capacity=1 --prune-threshold=20
 ```

--- a/bin/worker.ml
+++ b/bin/worker.ml
@@ -66,11 +66,11 @@ let worker_name =
 
 let connect_addr =
   Arg.required @@
-  Arg.pos 0 Arg.(some file) None @@
+  Arg.opt Arg.(some file) None @@
   Arg.info
     ~doc:"Path of register.cap from build-scheduler"
     ~docv:"ADDR"
-    []
+    ["c"; "connect"]
 
 let capacity =
   Arg.value @@


### PR DESCRIPTION
The client used an option `-c CAP`, but the worker used a positional argument `CAP`. Now, the worker uses an option too.

Cherry-picked from #128.