### PR TITLE
Make obuilder only require ppx_expect for the tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -16,7 +16,6 @@
 
 (library
   (name ocluster_expect_tests)
-  (package ocluster)
   (modules test_scheduling)
   (inline_tests)
   (preprocess (pps ppx_expect))


### PR DESCRIPTION
```
$ dune build -p ocluster
File "test/dune", line 22, characters 19-29:
22 |   (preprocess (pps ppx_expect))
                        ^^^^^^^^^^
Error: Library "ppx_expect" not found.
```