### PR TITLE
Sqlite3 remove usage of "FALSE" for compatibility with older versions

### DIFF
--- a/scheduler/pool.ml
+++ b/scheduler/pool.ml
@@ -162,7 +162,7 @@ module Dao = struct
     Sqlite3.exec db "CREATE TABLE IF NOT EXISTS workers ( \
                      pool       TEXT NOT NULL, \
                      id         TEXT NOT NULL, \
-                     paused     BOOLEAN DEFAULT FALSE, \
+                     paused     BOOLEAN DEFAULT 0, \
                      PRIMARY KEY (pool, id))" |> Db.or_fail ~cmd:"create workers table";
     let query_cache = Sqlite3.prepare db "SELECT worker FROM cached WHERE pool = ? AND cache_hint = ? ORDER BY worker" in
     let mark_cached = Sqlite3.prepare db "INSERT OR REPLACE INTO cached (pool, cache_hint, worker, created) VALUES (?, ?, ?, date('now'))" in


### PR DESCRIPTION
I had the misfortune of running the scheduler with sqlite 3.22.0 and encountering the error:

```
capnp-rpc [WARNING] Uncaught exception handling Registration.register:
(Failure "Bad row from DB: [TEXT <\"FALSE\">]")
```

Even though the schema specifies the column as BOOLEAN, this doesn't stop sqlite from writing strings into it. Turns out the aliases for TRUE/FALSE are [defined as 1/0 starting in 3.23.0](https://www.sqlite.org/quirks.html#no_separate_boolean_datatype). There is no easy way to setup a "strict mode" for the tables at the moment (they have a [draft](https://www.sqlite.org/draft/stricttables.html) and the alternative is to sprinkle `CHECK(typeof(column) = 'expected_type')` [everywhere](https://news.ycombinator.com/item?id=28259820)).

Anyway since sqlite 3.23.0 was released in 2018, ... I should probably upgrade my system!