### PR TITLE
Update Ocluster to be macOS capable

### DIFF
--- a/bin/worker.ml
+++ b/bin/worker.ml
@@ -41,7 +41,7 @@ let update_docker () =
 let update_normal () =
   Lwt.return (fun () -> Lwt.return ())
 
-let main default_level ?formatter registration_path capacity name allow_push prune_threshold state_dir obuilder =
+let main default_level ?formatter registration_path capacity name allow_push prune_threshold docker_max_df_size obuilder_prune_threshold state_dir obuilder =
   setup_log ?formatter default_level;
   let update =
     if Sys.file_exists "/.dockerenv" then update_docker
@@ -50,18 +50,18 @@ let main default_level ?formatter registration_path capacity name allow_push pru
   Lwt_main.run begin
     let vat = Capnp_rpc_unix.client_only_vat () in
     let sr = Capnp_rpc_unix.Cap_file.load vat registration_path |> or_die in
-    Cluster_worker.run ~capacity ~name ~allow_push ?prune_threshold ?obuilder ~state_dir ~update sr
+    Cluster_worker.run ~capacity ~name ~allow_push ?prune_threshold ?docker_max_df_size ?obuilder_prune_threshold ?obuilder ~state_dir ~update sr
   end
 
 (* Command-line parsing *)
 
-let main ~install (default_level, args1) ((registration_path, capacity, name, allow_push, prune_threshold, state_dir, obuilder), args2) =
+let main ~install (default_level, args1) ((registration_path, capacity, name, allow_push, prune_threshold, docker_max_df_size, obuilder_prune_threshold, state_dir, obuilder), args2) =
   let (name', display, text) = ("ocluster-worker", "OCluster Worker", "Run a build worker") in
   if install then
     `Ok (Winsvc_wrapper.install name' display text (args1 @ args2))
   else
     `Ok (Winsvc_wrapper.run name' state_dir (fun ?formatter () ->
-             main default_level ?formatter registration_path capacity name allow_push prune_threshold state_dir obuilder))
+             main default_level ?formatter registration_path capacity name allow_push prune_threshold docker_max_df_size obuilder_prune_threshold state_dir obuilder))
 
 open Cmdliner
 
@@ -93,9 +93,27 @@ let prune_threshold =
   Arg.value @@
   Arg.opt Arg.(some float) None @@
   Arg.info
-    ~doc:"Run 'docker system prune' when /var/lib/docker's free space falls below this (0-100)"
+    ~doc:"Run 'docker system prune' when /var/lib/docker's free space falls below this (0-100). \
+          If you don't have a partition for /var/lib/docker, then you can use docker-max-df-size."
     ~docv:"PERCENTAGE"
     ["prune-threshold"]
+
+let docker_max_df_size =
+  Arg.value @@
+  Arg.opt Arg.(some float) None @@
+  Arg.info
+    ~doc:"Run `docker system df` to get the amount of memory being taken up by the images and if this is \
+          greater than this we run `docker system prune`."
+    ~docv:"GIGABYTES"
+    ["docker-max-df-size"]
+
+let obuilder_prune_threshold =
+  Arg.value @@
+  Arg.opt Arg.(some float) None @@
+  Arg.info
+    ~doc:"If using OBuilder, this treshold is used to prune the stored builds if the free space falls below this (0-100)"
+    ~docv:"PERCENTAGE"
+    ["obuilder-prune-threshold"]
 
 let allow_push =
   Arg.value @@
@@ -134,11 +152,11 @@ module Obuilder_config = struct
 end
 
 let worker_opts_t =
-  let worker_opts registration_path capacity name allow_push prune_threshold state_dir obuilder =
-    (registration_path, capacity, name, allow_push, prune_threshold, state_dir, obuilder) in
+  let worker_opts registration_path capacity name allow_push prune_threshold docker_max_df_size obuilder_prune_threshold state_dir obuilder =
+    (registration_path, capacity, name, allow_push, prune_threshold, docker_max_df_size, obuilder_prune_threshold, state_dir, obuilder) in
   Term.(with_used_args
     (const worker_opts $ connect_addr $ capacity $ worker_name $ allow_push
-     $ prune_threshold $ state_dir $ Obuilder_config.v))
+     $ prune_threshold $ docker_max_df_size $ obuilder_prune_threshold $ state_dir $ Obuilder_config.v))
 
 let cmd ~install =
   let doc = "Run a build worker" in

--- a/bin/worker.ml
+++ b/bin/worker.ml
@@ -130,7 +130,7 @@ module Obuilder_config = struct
       | Some store -> Some (Cluster_worker.Obuilder_config.v sandbox_config store)
     in
     let open Cmdliner.Term in
-    Term.pure make $ Obuilder.Runc_sandbox.cmdliner $ store
+    Term.pure make $ Obuilder.Sandbox.cmdliner $ store
 end
 
 let worker_opts_t =

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -76,6 +76,7 @@ type t = {
     job_spec ->
     (string, [`Cancelled | `Msg of string]) Lwt_result.t;
   prune_threshold : float option;      (* docker-prune when free space is lower than this (percentage) *)
+  docker_max_df_size : float option;   (* docker-prune if [prune_threshold] is [None] and used space greater than this (GBs) *)
   registration_service : Cluster_api.Raw.Client.Registration.t Sturdy_ref.t;
   capacity : int;
   mutable in_use : int;                (* Number of active builds *)
@@ -167,15 +168,41 @@ let build ~switch ~log t descr =
     Log.info (fun f -> f "Job failed: %s" msg);
     Error (`Msg "Build failed"), "fail"
 
+let convert_memory_string s =
+  let length = String.length s in
+  match s.[length - 2], s.[length - 1] with
+   | 'G', 'B' -> float_of_string_opt (String.sub s 0 (length - 2))
+   | 'M', 'B' ->
+    Option.map (fun f -> f /. 1_000.) @@ float_of_string_opt (String.sub s 0 (length - 2))
+   | 'K', 'B' ->
+      Option.map (fun f -> f /. 1_000_000.) @@ float_of_string_opt (String.sub s 0 (length - 2))
+   | c, 'B' -> (
+     match int_of_string_opt (String.make 1 c) with
+       | Some _ -> Option.map (fun f -> f /. 1_000_000_000.) @@ float_of_string_opt (String.sub s 0 (length - 1))
+       | None -> None
+   )
+   | _ -> None
+
 let check_docker_partition t =
-  match t.prune_threshold with
-  | None -> Lwt_result.return ()
-  | Some prune_threshold ->
+  match t.prune_threshold, t.docker_max_df_size with
+  | None, None -> Lwt_result.return ()
+  | Some prune_threshold, _ ->
     Lwt_process.pread_line("", [| "docker"; "info"; "-f"; "{{.DockerRootDir}}" |]) >|= fun line ->
     let free = Df.free_space_percent (String.trim line) in
     Log.info (fun f -> f "Docker partition: %.0f%% free" free);
     if free < prune_threshold then Error `Disk_space_low
     else Ok ()
+  | _, Some max_df_size ->
+    (* Is the first one always the amount of memory the images take up? *)
+    Lwt_process.pread_line ("", [| "docker"; "system"; "df"; "--format"; "{{.Size}}" |]) >|= fun line ->
+    match convert_memory_string line with
+      | None ->
+          Log.info (fun f -> f "Failed to calculate max df size from %s" line);
+          Ok ()
+      | Some gb ->
+        Log.info (fun f -> f "Docker images take up %.0f%%GB" gb);
+        if max_df_size < gb then Error `Disk_space_low
+        else Ok ()
 
 let rec maybe_prune t queue =
   check_docker_partition t >>= function
@@ -436,15 +463,16 @@ let self_update ~update t =
        Lwt_result.fail (`Msg (Printexc.to_string ex))
     )
 
-let run ?switch ?build ?(allow_push=[]) ?prune_threshold ?obuilder ~update ~capacity ~name ~state_dir registration_service =
-  begin match prune_threshold with
-    | None -> Log.info (fun f -> f "Prune threshold not set. Will not check for low disk-space!")
-    | Some frac when frac < 0.0 || frac > 100.0 -> Fmt.invalid_arg "prune_threshold must be in the range 0 to 100"
-    | Some _ -> ()
+let run ?switch ?build ?(allow_push=[]) ?prune_threshold ?docker_max_df_size ?obuilder_prune_threshold ?obuilder ~update ~capacity ~name ~state_dir registration_service =
+  begin match prune_threshold, docker_max_df_size with
+    | None, None -> Log.info (fun f -> f "Prune threshold not set and docker max df size is not. Will not check for low disk-space!")
+    | None, Some size -> Log.info (fun f -> f "Pruning docker whenever the memory used exceeds %3.2fGB" size)
+    | Some frac, _ when frac < 0.0 || frac > 100.0 -> Fmt.invalid_arg "prune_threshold must be in the range 0 to 100"
+    | Some _, _ -> ()
   end;
   begin match obuilder with
     | None -> Lwt.return_none
-    | Some config -> Obuilder_build.create ?prune_threshold config >|= Option.some
+    | Some config -> Obuilder_build.create ?prune_threshold:obuilder_prune_threshold config >|= Option.some
   end >>= fun obuilder ->
   let build =
     match build with
@@ -455,6 +483,7 @@ let run ?switch ?build ?(allow_push=[]) ?prune_threshold ?obuilder ~update ~capa
     name;
     context = Context.v ~state_dir;
     prune_threshold;
+    docker_max_df_size;
     registration_service;
     build;
     cond = Lwt_condition.create ();

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -19,6 +19,8 @@ val run :
           (string, [`Cancelled | `Msg of string]) Lwt_result.t) ->
   ?allow_push:string list ->
   ?prune_threshold:float ->
+  ?docker_max_df_size:float ->
+  ?obuilder_prune_threshold:float ->
   ?obuilder:Obuilder_config.t ->
   update:(unit -> (unit -> unit Lwt.t) Lwt.t) ->
   capacity:int ->
@@ -36,7 +38,8 @@ val run :
                   finishes its remaining jobs. The second part is called once all jobs are finished.
                   If the second function returns, the process will exit.
     @param state_dir A persistent directory for Git caches, etc.
-    @param prune_threshold Stop and run "docker system prune -af" if free-space is less than this percentage (0 to 100). *)
+    @param prune_threshold Stop and run "docker system prune -af" if free-space is less than this percentage (0 to 100).
+    @param obuilder_prune_threshold The threshold for OBuilder to prune the store of cached build steps. *)
 
 module Process = Process
 module Log_data = Log_data

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -6,7 +6,7 @@ type job_spec = [
 module Obuilder_config : sig
   type t
 
-  val v : Obuilder.Runc_sandbox.config -> [ `Btrfs of string | `Rsync of string | `Zfs of string ] -> t
+  val v : Obuilder.Sandbox.config -> [ `Btrfs of string | `Rsync of string | `Zfs of string ] -> t
 end
 
 val run :

--- a/worker/obuilder_build.ml
+++ b/worker/obuilder_build.ml
@@ -7,7 +7,7 @@ type builder = Builder : (module Obuilder.BUILDER with type t = 'a) * 'a -> buil
 module Config = struct
   type t = {
     store_spec : [ `Btrfs of string | `Rsync of string | `Zfs of string ];
-    sandbox_config : Obuilder.Runc_sandbox.config;
+    sandbox_config : Obuilder.Sandbox.config;
   }
 
   let v sandbox_config store_spec = { store_spec; sandbox_config }
@@ -21,7 +21,7 @@ type t = {
   prune_threshold : float option;
 }
 
-module Sandbox = Obuilder.Runc_sandbox
+module Sandbox = Obuilder.Sandbox
 module Fetcher = Obuilder.Docker
 
 let ( / ) = Filename.concat

--- a/worker/obuilder_build.mli
+++ b/worker/obuilder_build.mli
@@ -3,7 +3,7 @@ type t
 module Config : sig
   type t
 
-  val v : Obuilder.Runc_sandbox.config -> [ `Btrfs of string | `Rsync of string | `Zfs of string ] -> t
+  val v : Obuilder.Sandbox.config -> [ `Btrfs of string | `Rsync of string | `Zfs of string ] -> t
 end
 
 val create : ?prune_threshold:float -> Config.t -> t Lwt.t


### PR DESCRIPTION
This is a companion PR to https://github.com/ocurrent/obuilder/pull/87 that updates OCluster worker to be:
 - Compatible with macOS sandboxing by using the abstract `Sandbox` interface.
 - The `Rsync` store backend.