### PR TITLE
Merge Obuilder with rsync store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ocaml/opam:debian-10-ocaml-4.12@sha256:9ce3fcbb65b4a23c56445d5c15e5009a37e904f0306586bbee57f8791a99f58c AS build
+FROM ocaml/opam:debian-11-ocaml-4.13@sha256:0c67662714d7f398ac4a8197d61ef85749effb8681d771837e9ebe36b0d4e20a AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin -q master && git reset --hard 9935f57dd3f9722e6ca803aeb232b49d7058abf8 && opam update
+RUN cd ~/opam-repository && git pull origin -q master && git reset --hard fbc1d981740a86692a63593aa3760a61f7b5072b && opam update
 COPY --chown=opam ocluster-api.opam ocluster.opam /src/
 COPY --chown=opam obuilder/obuilder.opam obuilder/obuilder-spec.opam /src/obuilder/
 RUN opam pin -yn /src/obuilder/
@@ -11,7 +11,7 @@ RUN opam config exec -- dune build \
   ./_build/install/default/bin/ocluster-scheduler \
   ./_build/install/default/bin/ocluster-admin
 
-FROM debian:10
+FROM debian:11
 RUN apt-get update && apt-get install libev4 libsqlite3-0 -y --no-install-recommends
 RUN apt-get install ca-certificates -y  # https://github.com/mirage/ocaml-conduit/issues/388
 WORKDIR /var/lib/ocluster-scheduler

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,6 +1,6 @@
-FROM ocaml/opam:debian-10-ocaml-4.12@sha256:9ce3fcbb65b4a23c56445d5c15e5009a37e904f0306586bbee57f8791a99f58c AS build
+FROM ocaml/opam:debian-11-ocaml-4.13@sha256:0c67662714d7f398ac4a8197d61ef85749effb8681d771837e9ebe36b0d4e20a AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin -q master && git reset --hard 9935f57dd3f9722e6ca803aeb232b49d7058abf8 && opam update
+RUN cd ~/opam-repository && git pull origin -q master && git reset --hard fbc1d981740a86692a63593aa3760a61f7b5072b && opam update
 COPY --chown=opam ocluster-api.opam ocluster.opam /src/
 COPY --chown=opam obuilder/obuilder.opam obuilder/obuilder-spec.opam /src/obuilder/
 RUN opam pin -yn /src/obuilder/
@@ -9,7 +9,7 @@ RUN opam install -y --deps-only .
 ADD --chown=opam . .
 RUN opam config exec -- dune build ./_build/install/default/bin/ocluster-worker
 
-FROM debian:10
+FROM debian:11
 RUN apt-get update && apt-get install docker.io libev4 curl gnupg2 git libsqlite3-dev ca-certificates netbase -y --no-install-recommends
 WORKDIR /var/lib/ocluster-worker
 ENTRYPOINT ["/usr/local/bin/ocluster-worker"]

--- a/bin/worker.ml
+++ b/bin/worker.ml
@@ -120,7 +120,7 @@ module Obuilder_config = struct
     Arg.value @@
     Arg.opt Arg.(some store_t) None @@
     Arg.info
-      ~doc:"zfs:pool or btrfs:/path for the OBuilder cache"
+      ~doc:"btrfs:/path or rsync:/path or zfs:pool for the OBuilder cache"
       ~docv:"STORE"
       ["obuilder-store"]
 

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -1,4 +1,4 @@
-type job_spec = [ 
+type job_spec = [
   | `Docker of [ `Contents of string | `Path of string ] * Cluster_api.Docker.Spec.options
   | `Obuilder of [ `Contents of string ]
 ]
@@ -6,7 +6,7 @@ type job_spec = [
 module Obuilder_config : sig
   type t
 
-  val v : Obuilder.Runc_sandbox.config -> [ `Zfs of string | `Btrfs of string ] -> t
+  val v : Obuilder.Runc_sandbox.config -> [ `Btrfs of string | `Rsync of string | `Zfs of string ] -> t
 end
 
 val run :

--- a/worker/obuilder_build.ml
+++ b/worker/obuilder_build.ml
@@ -6,7 +6,7 @@ type builder = Builder : (module Obuilder.BUILDER with type t = 'a) * 'a -> buil
 
 module Config = struct
   type t = {
-    store_spec : [ `Zfs of string | `Btrfs of string ];
+    store_spec : [ `Btrfs of string | `Rsync of string | `Zfs of string ];
     sandbox_config : Obuilder.Runc_sandbox.config;
   }
 
@@ -80,6 +80,7 @@ let do_prune ~path ~prune_threshold t =
 let store_path t =
   match t.config.store_spec with
   | `Btrfs path -> path
+  | `Rsync path -> path
   | `Zfs pool -> "/" ^ pool
 
 (* Check the free space in [t]'s store.

--- a/worker/obuilder_build.mli
+++ b/worker/obuilder_build.mli
@@ -3,7 +3,7 @@ type t
 module Config : sig
   type t
 
-  val v : Obuilder.Runc_sandbox.config -> [ `Zfs of string | `Btrfs of string ] -> t
+  val v : Obuilder.Runc_sandbox.config -> [ `Btrfs of string | `Rsync of string | `Zfs of string ] -> t
 end
 
 val create : ?prune_threshold:float -> Config.t -> t Lwt.t


### PR DESCRIPTION
Update vendored Obuilder with the rsync store, a requirement for both Docker and macOS branches.
cc @patricoferris 