### PR TITLE
Replace --verbose by -v in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ocluster-scheduler \
   --capnp-public-address=tcp:127.0.0.1:9000 \
   --state-dir=/var/lib/ocluster-scheduler \
   --pools=linux-arm32,linux-x86_64 \
-  --verbose
+  -v
 ```
 
 Replace the last line with whatever build pools you want. The names can be anything you like.
@@ -94,7 +94,7 @@ ocluster-worker \
   --connect=./capnp-secrets/pool-linux-x86_64.cap \
   --state-dir=/var/lib/ocluster-worker \
   --name=my-host --capacity=1 --prune-threshold=20 \
-  --verbose
+  -v
 ```
 
 Each builder must be given a unique name.


### PR DESCRIPTION
--verbose doesn't exist, to get info level of reporting use either -v
or --verbosity=info.

Close #154 .