### PR TITLE
Run `git submodule update` when resetting the git clone

### DIFF
--- a/worker/context.ml
+++ b/worker/context.ml
@@ -80,6 +80,7 @@ module Repo = struct
     end >>!= fun () ->
     (* This reset might avoid `fatal: cannot chdir to '../../../ocurrent': No such file or directory` errors *)
     Process.check_call ~label:"git-reset" ~switch ~log ["git"; "-C"; local_repo; "reset"; "--hard"] >>!= fun () ->
+    Process.check_call ~label:"git-submodule-sync" ~switch ~log ["git"; "-C"; local_repo; "submodule"; "sync"] >>!= fun () ->
     Process.check_call ~label:"git-submodule-deinit" ~switch ~log ["git"; "-C"; local_repo; "submodule"; "deinit"; "--all"; "-f"] >>!= fun () ->
     Process.check_call ~label:"git-fetch" ~switch ~log
       ["git"; "-C"; local_repo; "fetch"; "-q"; "--update-head-ok"; "--recurse-submodules=no"; "origin"]
@@ -121,6 +122,7 @@ let build_context t ~log ~tmpdir descr =
         end >>!= fun () ->
         let clone = Repo.local_copy repository in
         Process.check_call ~label:"git-reset" ~switch ~log ["git"; "-C"; clone; "reset"; "--hard"; Hash.to_hex c] >>!= fun () ->
+        Process.check_call ~label:"git-submodule-sync" ~switch ~log ["git"; "-C"; clone; "submodule"; "sync"] >>!= fun () ->
         Process.check_call ~label:"git-submodule-deinit" ~switch ~log ["git"; "-C"; clone; "submodule"; "deinit"; "--all"; "-f"] >>!= fun () ->
         Process.check_call ~label:"git-clean" ~switch ~log ["git"; "-C"; clone; "clean"; "-fdx"] >>!= fun () ->
         let merge c = Process.check_call ~label:"git-merge" ~switch ~log ~env:git_merge_env ["git"; "-C"; clone; "merge"; Hash.to_hex c] in


### PR DESCRIPTION
The submodule remote might have been updated. If we don't run this and
we have already a cache/clone of the repository, git won't use the new
remote url, leading to errors such as:

    Submodule 'ocaml-version' (https://github.com/ocurrent/ocaml-version.git) registered for path 'ocaml-version'
    fatal: remote error:
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
    Unable to fetch in submodule path 'ocaml-version'; trying to directly fetch a28dedbd8dcc325d665f5f7385cfe2afb85cbac5:
    fatal: remote error:
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
    Fetched in submodule path 'ocaml-version', but it did not contain a28dedbd8dcc325d665f5f7385cfe2afb85cbac5. Direct fetching of that commit failed.
    git-submodule-update failed with exit-code 1