### PR TITLE
Added --terse option to ocluster-admin-show and added new command ocluster-admin-exec

### DIFF
--- a/bin/admin.ml
+++ b/bin/admin.ml
@@ -56,12 +56,12 @@ let exec () cap_path pool prog =
   List.iter print_endline prog;
   run cap_path @@ fun admin_service ->
     Capability.with_ref (Cluster_api.Admin.pool admin_service pool) @@ fun pool ->
-    Cluster_api.Pool_admin.workers pool >|= fun workers -> ignore(
-    List.map (fun (w:Cluster_api.Pool_admin.worker_info) ->
+    Cluster_api.Pool_admin.workers pool >|= fun workers -> 
+            List.iter (fun (w:Cluster_api.Pool_admin.worker_info) ->
             let ar = Array.of_list prog in
             let ar2 = Array.map (fun el -> if el = "{}" then w.name else el) ar in
-            Lwt_process.exec ("", ar2 )
-    ) workers )
+            ignore( Lwt_process.exec ("", ar2 ) )
+    ) workers
 
 let with_progress label =
   Capability.with_ref (Cluster_api.Progress.local (Fmt.pr "%s: %s@." label))


### PR DESCRIPTION
This is handy when running commands on all the pool workers, such as:

    for a in `ci3-admin show --terse linux-x86_64` ; do ssh $a uptime ; done