### PR TITLE
Upgrade lwt to 5.5.0

### DIFF
--- a/current_ocluster.opam
+++ b/current_ocluster.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8"}
   "ppx_deriving"
   "ocluster-api" {= version}
-  "lwt" {>= "5.4.1"}
+  "lwt" {>= "5.5.0"}
   "current" {>= "0.3"}
   "current_git" {>= "0.3"}
   "current_web" {>= "0.3" & with-test}

--- a/ocluster-api.opam
+++ b/ocluster-api.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ocurrent/ocluster/issues"
 depends: [
   "dune" {>= "2.8"}
   "ppx_deriving"
-  "lwt" {>= "5.4.1"}
+  "lwt" {>= "5.5.0"}
   "capnp-rpc-lwt" {>= "1.2"}
   "fmt"
   "ppx_deriving_yojson"

--- a/ocluster.opam
+++ b/ocluster.opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_sexp_conv"
   "dune-build-info"
   "ocluster-api" {= version}
-  "lwt" {>= "5.4.1"}
+  "lwt" {>= "5.5.0"}
   "capnp-rpc-lwt"
   "capnp-rpc-net"
   "capnp-rpc-unix" {>= "1.2"}


### PR DESCRIPTION
This PR fixes dependencies issues in the opam files with `lwt`. With older versions, it triggers this error as the signature has changed in `5.5.0`:
```
File "obuilder/lib/os.ml", line 97, characters 13-29:
97 |   let r, w = Lwt_unix.pipe_in ~cloexec:true () in
                  ^^^^^^^^^^^^^^^^
Error: This function has type unit -> Lwt_unix.file_descr * Unix.file_descr
       It is applied to too many arguments; maybe you forgot a `;'.
```