### PR TITLE
Default to GitLab merge-requests refspecs

### DIFF
--- a/worker/context.ml
+++ b/worker/context.ml
@@ -77,8 +77,10 @@ module Repo = struct
         config "remote.origin.fetch" "+refs/heads/*:refs/remotes/origin/*" >>!= fun () ->
         config "remote.origin.fetch"
           (match Uri.host t.url with
-           | Some "gitlab.com" -> "+refs/merge-requests/*/head:refs/remotes/origin/merge-requests/*"
-           | Some "github.com" | _ -> "+refs/pull/*:refs/remotes/pull/*")
+           | Some "github.com" -> "+refs/pull/*:refs/remotes/pull/*"
+           | Some "gitlab.com"
+           (* Default to GitLab merge requests refspec for self-hosted instances *)
+           | _ -> "+refs/merge-requests/*/head:refs/remotes/origin/merge-requests/*")
       )
     end >>!= fun () ->
     Process.check_call ~label:"git-submodule-update" ~switch ~log ["git"; "-C"; local_repo; "submodule"; "update"] >>!= fun () ->


### PR DESCRIPTION
GitLab offers self-hosted instances. It might not be possible to tell
from the URL if the repository if web-hosted on a GitLab instance.
Considering that GitHub doesn't provide self-hosted instances, default
to GitLab.

Gitea/Gogs use GitHub style, so they're currently left out.
Bitbucket doesn't seem to provide that feature.