### PR TITLE
Use OBuilder to configure the store

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "obuilder"]
 	path = obuilder
-	url = https://github.com/ocurrent/obuilder.git
-	branch = master
+	url = https://github.com/MisterDA/obuilder.git
+	branch = non-req-cmdliner

--- a/bin/worker.ml
+++ b/bin/worker.ml
@@ -114,22 +114,12 @@ let state_dir =
     ["state-dir"]
 
 module Obuilder_config = struct
-  let store_t = Arg.conv Obuilder.Store_spec.(of_string, pp)
-
-  let store =
-    Arg.value @@
-    Arg.opt Arg.(some store_t) None @@
-    Arg.info
-      ~doc:"btrfs:/path or rsync:/path or zfs:pool for the OBuilder cache"
-      ~docv:"STORE"
-      ["obuilder-store"]
-
   let v =
     let make sandbox_config = function
       | None -> None
-      | Some store -> Some (Cluster_worker.Obuilder_config.v sandbox_config store)
+      | Some store_spec -> Some (Cluster_worker.Obuilder_config.v sandbox_config store_spec)
     in
-    Term.(const make $ Obuilder.Runc_sandbox.cmdliner $ store)
+    Term.(const make $ Obuilder.Runc_sandbox.cmdliner $ Obuilder.Store_spec.cmdliner')
 end
 
 let worker_opts_t =

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -4,13 +4,9 @@ type job_spec = [
   | `Custom of Cluster_api.Custom.recv
 ]
 
-module Obuilder_config : sig
-  type t
+module Obuilder_config = Obuilder_build.Config
 
-  val v : Obuilder.Runc_sandbox.config -> [ `Btrfs of string | `Rsync of string | `Zfs of string ] -> t
-end
-
-type build = 
+type build =
   switch:Lwt_switch.t ->
   log:Log_data.t ->
   src:string ->

--- a/worker/obuilder_build.mli
+++ b/worker/obuilder_build.mli
@@ -3,7 +3,7 @@ type t
 module Config : sig
   type t
 
-  val v : Obuilder.Runc_sandbox.config -> [ `Btrfs of string | `Rsync of string | `Zfs of string ] -> t
+  val v : Obuilder.Runc_sandbox.config -> Obuilder.Store_spec.store Lwt.t -> t
 end
 
 val create : ?prune_threshold:float -> Config.t -> t Lwt.t


### PR DESCRIPTION
This limits a bit code duplication by configuring the OBuilder store fully inside OBuilder. It also allows exposing the store configuration (e.g., the rsync mode) to the command line.

(revert the changes to `.gitmodules` when the OBuilder PR is merged)

- https://github.com/ocurrent/obuilder/pull/119