### PR TITLE
Worker detects low inode count on the Docker partition

### DIFF
--- a/worker/df.ml
+++ b/worker/df.ml
@@ -1,14 +1,17 @@
+let normalise_path root_dir =
+  if Sys.win32 then
+    let vol, _ = Fpath.(v root_dir |> split_volume) in
+    vol ^ "\\"
+  else
+    root_dir
+
 let free_space_percent root_dir =
-  let root_dir =
-    if Sys.win32 then
-      let vol, _ = Fpath.(v root_dir |> split_volume) in
-      vol ^ "\\"
-    else
-      root_dir
-  in
-  let vfs = ExtUnix.All.statvfs root_dir in
-  let used_blocks = Int64.sub vfs.f_blocks vfs.f_bfree in
-  let used_files = Int64.sub vfs.f_files vfs.f_ffree in
-  let percent_free_blocks = 100. -. 100. *. (Int64.to_float used_blocks) /. (Int64.to_float (Int64.add used_blocks vfs.f_bavail)) in
-  let percent_free_files = 100. -. 100. *. (Int64.to_float used_files) /. (Int64.to_float (Int64.add used_files vfs.f_favail)) in
-  min percent_free_blocks percent_free_files
+  let vfs = ExtUnix.All.statvfs (normalise_path root_dir) in
+  let used = Int64.sub vfs.f_blocks vfs.f_bfree in
+  100. -. 100. *. (Int64.to_float used) /. (Int64.to_float (Int64.add used vfs.f_bavail))
+
+let free_files_percent root_dir =
+  let vfs = ExtUnix.All.statvfs (normalise_path root_dir) in
+  let used = Int64.sub vfs.f_files vfs.f_ffree in
+  100. -. 100. *. (Int64.to_float used) /. (Int64.to_float (Int64.add used vfs.f_favail))
+

--- a/worker/df.ml
+++ b/worker/df.ml
@@ -7,5 +7,8 @@ let free_space_percent root_dir =
       root_dir
   in
   let vfs = ExtUnix.All.statvfs root_dir in
-  let used = Int64.sub vfs.f_blocks vfs.f_bfree in
-  100. -. 100. *. (Int64.to_float used) /. (Int64.to_float (Int64.add used vfs.f_bavail))
+  let used_blocks = Int64.sub vfs.f_blocks vfs.f_bfree in
+  let used_files = Int64.sub vfs.f_files vfs.f_ffree in
+  let percent_free_blocks = 100. -. 100. *. (Int64.to_float used_blocks) /. (Int64.to_float (Int64.add used_blocks vfs.f_bavail)) in
+  let percent_free_files = 100. -. 100. *. (Int64.to_float used_files) /. (Int64.to_float (Int64.add used_files vfs.f_favail)) in
+  min percent_free_blocks percent_free_files


### PR DESCRIPTION
Many of the workers have now been reformatted with a higher number of inodes but for those that haven't this PR causes the worker to check if the number of free inodes falls below `prune_threshold`.  See Issue [189](https://github.com/tarides/infrastructure/issues/189)