### PR TITLE
Added worker capacity to Prometheus metrics

### DIFF
--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -286,7 +286,6 @@ let loop ~switch ?obuilder t queue =
         pop >>= fun request ->
         t.in_use <- t.in_use + 1;
         Prometheus.Gauge.set Metrics.running_jobs (float_of_int t.in_use);
-        Prometheus.Gauge.set Metrics.capacity (float_of_int t.capacity);
         Prometheus.Counter.inc_one Metrics.jobs_accepted;
         Lwt.async (fun () ->
             Lwt.finalize
@@ -455,6 +454,7 @@ let self_update ~update t =
     )
 
 let run ?switch ?build ?(allow_push=[]) ?prune_threshold ?obuilder ~update ~capacity ~name ~state_dir registration_service =
+  Prometheus.Gauge.set Metrics.capacity (float_of_int capacity);
   begin match prune_threshold with
     | None -> Log.info (fun f -> f "Prune threshold not set. Will not check for low disk-space!")
     | Some frac when frac < 0.0 || frac > 100.0 -> Fmt.invalid_arg "prune_threshold must be in the range 0 to 100"

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -30,6 +30,10 @@ module Metrics = struct
     let help = "Number of jobs currently running" in
     Gauge.v ~help ~namespace ~subsystem "running_jobs"
 
+  let capacity =
+    let help = "Maximum number of jobs" in
+    Gauge.v ~help ~namespace ~subsystem "capacity"
+
   let healthcheck_time =
     let help = "Time to perform last healthcheck" in
     Gauge.v ~help ~namespace ~subsystem "healthcheck_time_seconds"
@@ -282,6 +286,7 @@ let loop ~switch ?obuilder t queue =
         pop >>= fun request ->
         t.in_use <- t.in_use + 1;
         Prometheus.Gauge.set Metrics.running_jobs (float_of_int t.in_use);
+        Prometheus.Gauge.set Metrics.capacity (float_of_int t.capacity);
         Prometheus.Counter.inc_one Metrics.jobs_accepted;
         Lwt.async (fun () ->
             Lwt.finalize


### PR DESCRIPTION
Added a `capacity` metric to `ocluster-worker` to allow us to centrally report on how busy a worker is.

Thus in Grafana, we could graph on

    ocluster_worker_running_jobs{job="workername"}/ocluster_worker_capacity{job="workername"}

As this value is fixed it only needs to be set once but for readability, I have kept it together with the other metrics which are set once per job.  Happy to move it if there is a preferred/better place.