### PR TITLE
Update to Obuilder 0.5 (macOS, Docker & Windows prerequisites)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "obuilder"]
+	path = obuilder
+	url = https://github.com/ocurrent/obuilder.git
+	branch = master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ocaml/opam:debian-11-ocaml-4.14@sha256:698cd4a3d59912f89deb3c8cb05b9299a870b27086d212877f5f3c88f4021b74 AS build
+FROM ocaml/opam:debian-11-ocaml-4.14@sha256:1161c383ca79f11d5e5d7fc69910ac255871fde0cbc0815faa0a6424f929b181 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 57f1b681ce75766a17f15588c2088174edbb89c9 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 56a03100e6d037e7c0e116ed34ec87b11aa3b592 && opam update
 COPY --chown=opam ocluster-api.opam ocluster.opam /src/
 COPY --chown=opam obuilder/obuilder.opam obuilder/obuilder-spec.opam /src/obuilder/
 RUN opam pin -yn /src/obuilder/

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,6 +1,6 @@
-FROM ocaml/opam:ubuntu-22.04-ocaml-4.14@sha256:3d379b4a575d050ea02b1146f03d7ab28ccf15e6fecdada5595b0b04a8a307d0 AS build
+FROM ocaml/opam:debian-11-ocaml-4.14@sha256:1161c383ca79f11d5e5d7fc69910ac255871fde0cbc0815faa0a6424f929b181 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 57f1b681ce75766a17f15588c2088174edbb89c9 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 56a03100e6d037e7c0e116ed34ec87b11aa3b592 && opam update
 COPY --chown=opam ocluster-api.opam ocluster.opam /src/
 COPY --chown=opam obuilder/obuilder.opam obuilder/obuilder-spec.opam /src/obuilder/
 RUN opam pin -yn /src/obuilder/

--- a/test/dune
+++ b/test/dune
@@ -16,7 +16,6 @@
 
 (library
   (name ocluster_expect_tests)
-  (package ocluster)
   (modules test_scheduling)
   (inline_tests)
   (preprocess (pps ppx_expect))


### PR DESCRIPTION
Obuilder was (mistakenly?) reverted to an older version in 7e1cf4e4c6f15868c79a3523296e7c665f633a0d.