### PR TITLE
Allow workers to report additional prometheus metrics

### DIFF
--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -76,7 +76,7 @@ struct JobDescr {
   # If there are multiple items, they will be merged.
 
   secrets @5 :List(Secret);
-  # Secret id-value pairs provided to the job. 
+  # Secret id-value pairs provided to the job.
 }
 
 interface Job {
@@ -108,6 +108,18 @@ interface Queue {
   # prune or upgrade), but still wants to provide metrics.
 }
 
+struct Metric {
+  contentType @0 :Text;
+  data        @1 :Text;
+}
+
+struct AdditionalMetric {
+  union {
+    metric @0 :Metric;
+    notReported @1 :Void;
+  }
+}
+
 interface Worker {
   enum MetricsSource {
     agent @0;   # Report the agent's own metrics
@@ -116,6 +128,9 @@ interface Worker {
 
   metrics    @0 (source :MetricsSource) -> (contentType :Text, data :Text);
   # Get Prometheus metrics.
+
+  additionalMetric @2 (source :Text) -> (metric: AdditionalMetric);
+  # Additional prometheus metrics reported by the worker
 
   selfUpdate @1 () -> ();
   # Finish any running jobs and then restart, running the latest version.

--- a/bin/worker.ml
+++ b/bin/worker.ml
@@ -42,25 +42,28 @@ let update_docker () =
 let update_normal () =
   Lwt.return (fun () -> Lwt.return ())
 
-let main ?style_renderer level ?formatter registration_path capacity name allow_push prune_threshold docker_max_df_size obuilder_prune_threshold state_dir obuilder =
+let main ?style_renderer level ?formatter registration_path capacity name allow_push prune_threshold docker_max_df_size obuilder_prune_threshold state_dir obuilder additional_metrics =
   setup_log ?style_renderer ?formatter level;
   let update =
     if Sys.file_exists "/.dockerenv" then update_docker
     else update_normal
   in
+  let _check_for_duplicates =
+    List.fold_left (fun acc (v, _) -> if List.mem v acc then failwith ("Duplicate additional metrics name: " ^ v) else v :: acc) [] additional_metrics
+  in
   Lwt_main.run begin
     let vat = Capnp_rpc_unix.client_only_vat () in
     let sr = Capnp_rpc_unix.Cap_file.load vat registration_path |> or_die in
-    Cluster_worker.run ~capacity ~name ~allow_push ?prune_threshold ?docker_max_df_size ?obuilder_prune_threshold ?obuilder ~state_dir ~update sr
+    Cluster_worker.run ~capacity ~name ~allow_push ?prune_threshold ?docker_max_df_size ?obuilder_prune_threshold ?obuilder ~additional_metrics ~state_dir ~update sr
   end
 
 (* Command-line parsing *)
-let main ~install (style_renderer, args1) (level, args2) ((registration_path, capacity, name, allow_push, prune_threshold, docker_max_df_size, obuilder_prune_threshold, state_dir, obuilder), args3) =
+let main ~install (style_renderer, args1) (level, args2) ((registration_path, capacity, name, allow_push, prune_threshold, docker_max_df_size, obuilder_prune_threshold, state_dir, obuilder, additional_metrics), args3) =
   if install then
     Ok (Winsvc_wrapper.install name "OCluster Worker" "Run a build worker" (args1 @ args2 @ args3))
   else
     Ok (Winsvc_wrapper.run name state_dir (fun ?formatter () ->
-             main ?style_renderer level ?formatter registration_path capacity name allow_push prune_threshold docker_max_df_size obuilder_prune_threshold state_dir obuilder))
+             main ?style_renderer level ?formatter registration_path capacity name allow_push prune_threshold docker_max_df_size obuilder_prune_threshold state_dir obuilder additional_metrics))
 
 open Cmdliner
 
@@ -130,6 +133,23 @@ let state_dir =
     ~docv:"PATH"
     ["state-dir"]
 
+let additional_metric_conv =
+  let of_string s = match Astring.String.cut ~sep:":" s with
+    | Some (name, uri) -> Ok (name, Uri.of_string uri)
+    | None -> Error (`Msg ("Malformed additional metric " ^ s))
+  in
+  let pp ppf (name, uri) = Fmt.pf ppf "%s:%a" name Uri.pp uri in
+  Arg.conv (of_string, pp)
+
+let additional_metrics =
+  Arg.value @@
+  Arg.opt Arg.(list additional_metric_conv) [] @@
+  Arg.info
+    ~doc:"Additional prometheus endpoints to scrape in the form <name>:<uri> \
+    presented as a comma separated list."
+    ~docv:"METRICS"
+    ["additional-metrics"]
+
 module Obuilder_config = struct
   let v =
     let make sandbox_config store = Some (Cluster_worker.Obuilder_config.v sandbox_config store) in
@@ -137,11 +157,11 @@ module Obuilder_config = struct
 end
 
 let worker_opts_t =
-  let worker_opts registration_path capacity name allow_push prune_threshold docker_max_df_size obuilder_prune_threshold state_dir obuilder =
-    (registration_path, capacity, name, allow_push, prune_threshold, docker_max_df_size, obuilder_prune_threshold, state_dir, obuilder) in
+  let worker_opts registration_path capacity name allow_push prune_threshold docker_max_df_size obuilder_prune_threshold state_dir obuilder additional_metrics =
+    (registration_path, capacity, name, allow_push, prune_threshold, docker_max_df_size, obuilder_prune_threshold, state_dir, obuilder, additional_metrics) in
   Term.(with_used_args
     (const worker_opts $ connect_addr $ capacity $ worker_name $ allow_push
-     $ prune_threshold $ docker_max_df_size $ obuilder_prune_threshold $ state_dir $ Obuilder_config.v))
+     $ prune_threshold $ docker_max_df_size $ obuilder_prune_threshold $ state_dir $ Obuilder_config.v $ additional_metrics))
 
 let cmd ~install =
   let doc = "Run a build worker" in

--- a/stress/worker.ml
+++ b/stress/worker.ml
@@ -30,7 +30,7 @@ let thread ~name ~capacity pool =
   let worker =
     let metrics _ = failwith "fake metrics" in
     let self_update _ = failwith "fake self_update" in
-    Api.Worker.local ~metrics ~self_update
+    Api.Worker.local ~metrics ~self_update ()
   in
   Capability.with_ref (Api.Registration.register pool ~name ~capacity worker) @@ fun queue ->
   let t = { name; capacity; in_use = 0; cond = Lwt_condition.create (); cached = Hint_set.empty } in
@@ -43,7 +43,7 @@ let thread ~name ~capacity pool =
       Log.info (fun f -> f "Requesting a new job…");
       let switch = Lwt_switch.create () in
       let pop =
-        let stream_log_data ~start:_ = 
+        let stream_log_data ~start:_ =
           outcome >>= fun _ ->
           Lwt.return ("", 0L)
         in

--- a/test/test.ml
+++ b/test/test.ml
@@ -144,7 +144,7 @@ let await_builder () =
 (* Two workers register with the same name. *)
 let already_registered () =
   with_sched @@ fun ~admin:_ ~registry ->
-  let api = Cluster_api.Worker.local ~metrics:(fun _ -> assert false) ~self_update:(fun () -> assert false) in
+  let api = Cluster_api.Worker.local ~metrics:(fun _ -> assert false) ~self_update:(fun () -> assert false) () in
   let q1 = Cluster_api.Registration.register registry ~name:"worker-1" ~capacity:1 api in
   Capability.await_settled q1 >>= fun (_ : _ result) ->
   let q2 = Cluster_api.Registration.register registry ~name:"worker-1" ~capacity:1 api in

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -66,7 +66,7 @@ type job_spec = [
   | `Custom of Cluster_api.Custom.recv
 ]
 
-type build = 
+type build =
   switch:Lwt_switch.t ->
   log:Log_data.t ->
   src:string ->
@@ -427,15 +427,10 @@ let default_build ?obuilder ~switch ~log ~src ~secrets = function
     Log.warn (fun f -> f "The default cluster_worker build does not support any custom jobs (kind: %s)" (Cluster_api.Custom.kind c));
     Lwt.return @@ Error (`Msg "Unsupported custom job")
 
-let metrics = function
-  | `Agent ->
-    Prometheus.CollectorRegistry.(collect default) >>= fun data ->
-    let content_type = "text/plain; version=0.0.4; charset=utf-8" in
-    Lwt_result.return (content_type, Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output data)
-  | `Host ->
-    Lwt.catch
+let collect_external_metric uri =
+  Lwt.catch
       (fun () ->
-         Cohttp_lwt_unix.Client.get (Uri.of_string "http://127.0.0.1:9100/metrics") >>= fun (resp, body) ->
+         Cohttp_lwt_unix.Client.get uri >>= fun (resp, body) ->
          match Cohttp.Response.status resp with
          | `OK ->
            begin match Cohttp.Header.get (Cohttp.Response.headers resp) "content-type" with
@@ -453,6 +448,22 @@ let metrics = function
          Log.warn (fun f -> f "Failed to connect to prometheus-node-exporter: %a" Fmt.exn ex);
          Lwt.return @@ Fmt.error_msg "Failed to connect to prometheus-node-exporter"
       )
+
+let metrics = function
+  | `Agent ->
+    Prometheus.CollectorRegistry.(collect default) >>= fun data ->
+    let content_type = "text/plain; version=0.0.4; charset=utf-8" in
+    Lwt_result.return (content_type, Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output data)
+  | `Host ->
+    collect_external_metric (Uri.of_string "http://127.0.0.1:9100/metrics")
+
+let collect_additional_metrics metrics s =
+  match List.assoc_opt s metrics with
+  | None -> Lwt.return (Ok None)
+  | Some uri ->
+    collect_external_metric uri >>= function Ok (content_type, data) ->
+    Lwt.return @@ Ok (Some (content_type, data))
+  | Error _ as e -> Lwt.return e
 
 let self_update ~update t =
   Lwt.catch
@@ -476,7 +487,7 @@ let self_update ~update t =
        Lwt_result.fail (`Msg (Printexc.to_string ex))
     )
 
-let run ?switch ?build ?(allow_push=[]) ?prune_threshold ?docker_max_df_size ?obuilder_prune_threshold ?obuilder ~update ~capacity ~name ~state_dir registration_service =
+let run ?switch ?build ?(allow_push=[]) ?prune_threshold ?docker_max_df_size ?obuilder_prune_threshold ?obuilder ?(additional_metrics=[]) ~update ~capacity ~name ~state_dir registration_service =
   begin match prune_threshold, docker_max_df_size with
     | None, None -> Log.info (fun f -> f "Prune threshold not set and docker max df size is not. Will not check for low disk-space!")
     | None, Some size -> Log.info (fun f -> f "Pruning docker whenever the memory used exceeds %3.2fGB" size)
@@ -519,7 +530,8 @@ let run ?switch ?build ?(allow_push=[]) ?prune_threshold ?docker_max_df_size ?ob
          Sturdy_ref.connect_exn t.registration_service >>= fun reg ->
          Capability.with_ref reg @@ fun reg ->
          let queue =
-           let api = Cluster_api.Worker.local ~metrics ~self_update:(fun () -> self_update ~update t) in
+           let additional_metric s = collect_additional_metrics additional_metrics s in
+           let api = Cluster_api.Worker.local ~additional_metric ~metrics ~self_update:(fun () -> self_update ~update t) () in
            let queue = Cluster_api.Registration.register reg ~name ~capacity api in
            Capability.dec_ref api;
            queue

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -10,7 +10,7 @@ module Obuilder_config : sig
   val v : Obuilder.Sandbox.config -> Obuilder.Store_spec.t -> t
 end
 
-type build = 
+type build =
   switch:Lwt_switch.t ->
   log:Log_data.t ->
   src:string ->
@@ -29,6 +29,7 @@ val run :
   ?docker_max_df_size:float ->
   ?obuilder_prune_threshold:float ->
   ?obuilder:Obuilder_config.t ->
+  ?additional_metrics:(string * Uri.t) list ->
   update:(unit -> (unit -> unit Lwt.t) Lwt.t) ->
   capacity:int ->
   name:string ->
@@ -46,7 +47,8 @@ val run :
                   If the second function returns, the process will exit.
     @param state_dir A persistent directory for Git caches, etc.
     @param prune_threshold Stop and run "docker system prune -af" if free-space is less than this percentage (0 to 100).
-    @param obuilder_prune_threshold The threshold for OBuilder to prune the store of cached build steps. *)
+    @param obuilder_prune_threshold The threshold for OBuilder to prune the store of cached build steps.
+    @param additional_metrics A list of additional prometheus endpoints with a descriptive name to collect. *)
 
 module Process = Process
 module Log_data = Log_data


### PR DESCRIPTION
In order to support workers reporting energy metrics we need to allow them to proxy more prometheus endpoints. I've added an `additional_metric` method to the worker interface to let them do this where we can add an arbitrary number of `<name>:<uri>` pairs for the worker to collect similarly to what is currently done by the `node-exporter`. 

This would allow us to then run [clarke](https://github.com/patricoferris/clarke) on some workers and have them proxy the prometheus metrics, in addition to that we could run [other prometheus reporters](https://prometheus.io/docs/instrumenting/exporters/) too.

I'll need to set up some things in order to test this properly but thought I would open the PR now to get some thoughts on the API. 