### PR TITLE
Smother Cap'n Proto and TLS debug logs

### DIFF
--- a/bin/worker.ml
+++ b/bin/worker.ml
@@ -1,7 +1,10 @@
 open Lwt.Infix
 
 let setup_log ?style_renderer ?formatter default_level =
-  Prometheus_unix.Logging.init ?formatter ?default_level ();
+  (* Smother Cap'n Proto and TLS logging sources *)
+  let levels = ["capnp-rpc"; "tls.config"; "tls.tracing"; "endpoint"]
+               |> List.map (fun src -> src, Logs.Warning) in
+  Prometheus_unix.Logging.init ?formatter ?default_level ~levels ();
   Fmt_tty.setup_std_outputs ?style_renderer ();
   ()
 


### PR DESCRIPTION
These log sources add a lot of noise when debugging. The networking interface has been stable for some time now, and I want to be able by default to debug using logging messages the worker and obuilder, so I need some kind of filtering.
Is this the most efficient / cleanest way to do it?