### PR TITLE
Added command line option to set obuilder health check period

### DIFF
--- a/test/mock_builder.ml
+++ b/test/mock_builder.ml
@@ -90,14 +90,14 @@ let update () =
   Lwt.return (fun () -> failwith "Mock restart")
 
 let run ?(capacity=1) ?(name="worker-1") ~switch t registration_service =
-  let thread = Cluster_worker.run ~switch ~capacity ~name ~build:(build t) ~update ~state_dir registration_service in
+  let thread = Cluster_worker.run ~switch ~capacity ~name ~build:(build t) ~healthcheck_period:600.0 ~update ~state_dir registration_service in
   Lwt.on_failure thread
     (fun ex -> if Lwt_switch.is_on switch then raise ex)
 
 let run_remote ~builder_switch ~network_switch ?(capacity=1) ?(name="worker-1") t registration_service =
   let thread =
     let registration_service = Mock_network.remote ~switch:network_switch registration_service in
-    Cluster_worker.run ~switch:builder_switch ~capacity ~name ~build:(build t) ~update ~state_dir registration_service
+    Cluster_worker.run ~switch:builder_switch ~capacity ~name ~build:(build t) ~healthcheck_period:600.0 ~update ~state_dir registration_service
   in
   Lwt.on_failure thread
     (fun ex ->

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -25,6 +25,7 @@ val run :
   ?switch:Lwt_switch.t ->
   ?build:build ->
   ?allow_push:string list ->
+  healthcheck_period:float ->
   ?prune_threshold:float ->
   ?docker_max_df_size:float ->
   ?obuilder_prune_threshold:float ->


### PR DESCRIPTION
For macOS workers, 10 minutes effectively means that the health check runs after every job.  This PR adds a command line option to increase the interval or stop it altogether.

I used the Cmdliner to get the default value of 600 seconds: `Arg.opt Arg.float 600.0`.  However, it may be preferable to use `Arg.opt Arg.(some float) None` and remove the `option` in the initialisation steps of the `run` function in `worker/cluster_worker.ml`.