### PR TITLE
Update OBuilder, lower-bounds, list authors

### DIFF
--- a/current_ocluster.opam
+++ b/current_ocluster.opam
@@ -4,7 +4,16 @@ synopsis: "OCurrent plugin for OCluster builds"
 description:
   "Creates a stage in an OCurrent pipeline for submitting jobs to OCluster."
 maintainer: ["talex5@gmail.com"]
-authors: ["talex5@gmail.com"]
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
 license: "Apache-2.0"
 homepage: "https://github.com/ocurrent/ocluster"
 doc: "https://ocurrent.github.io/ocluster/"

--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
  (description "OCluster library for defining workers")
  (depends
   (ocluster-api (= :version))
-  (ocaml (>= 4.12.0))
+  (ocaml (>= 4.14.1))
   (capnp-rpc-lwt (>= 1.2.3))
   (cohttp-lwt-unix (>= 4.0))
   (digestif (>= 0.8))
@@ -53,11 +53,11 @@
  (depends
   (ocluster-api (= :version))
   (ocluster-worker (= :version))
-  (ocaml (>= 4.12.0))
+  (ocaml (>= 4.14.1))
   (capnp-rpc-lwt (>= 1.2.3))
   (capnp-rpc-net (>= 1.2.3))
   (capnp-rpc-unix (>= 1.2.3))
-  (cmdliner (>= 1.1.1))
+  (cmdliner (>= 1.2.0))
   (conf-libev (<> :os "win32"))
   (digestif (>= 0.8))
   dune-build-info

--- a/dune-project
+++ b/dune-project
@@ -5,7 +5,15 @@
 
 (source (github ocurrent/ocluster))
 (documentation "https://ocurrent.github.io/ocluster/")
-(authors "talex5@gmail.com")
+(authors
+ "Antonin Décimo <antonin@tarides.com>"
+ "David Allsopp <david.allsopp@metastack.com>"
+ "Kate <kit.ty.kate@disroot.org>"
+ "Lucas Pluvinage <lucas@tarides.com>"
+ "Mark Elvers <mark.elvers@tunbury.org>"
+ "Patrick Ferris <patrick@sirref.org>"
+ "Thomas Leonard <talex5@gmail.com>"
+ "Tim McGilchrist <timmcgil@gmail.com>")
 (maintainers "talex5@gmail.com")
 (license "Apache-2.0")
 

--- a/ocluster-api.opam
+++ b/ocluster-api.opam
@@ -3,7 +3,16 @@ opam-version: "2.0"
 synopsis: "Cap'n Proto API for OCluster"
 description: "OCaml bindings for the OCluster Cap'n Proto API."
 maintainer: ["talex5@gmail.com"]
-authors: ["talex5@gmail.com"]
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
 license: "Apache-2.0"
 homepage: "https://github.com/ocurrent/ocluster"
 doc: "https://ocurrent.github.io/ocluster/"

--- a/ocluster-worker.opam
+++ b/ocluster-worker.opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocurrent/ocluster/issues"
 depends: [
   "dune" {>= "3.7"}
   "ocluster-api" {= version}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.14.1"}
   "capnp-rpc-lwt" {>= "1.2.3"}
   "cohttp-lwt-unix" {>= "4.0"}
   "digestif" {>= "0.8"}

--- a/ocluster-worker.opam
+++ b/ocluster-worker.opam
@@ -3,7 +3,16 @@ opam-version: "2.0"
 synopsis: "OCluster library for defining workers"
 description: "OCluster library for defining workers"
 maintainer: ["talex5@gmail.com"]
-authors: ["talex5@gmail.com"]
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
 license: "Apache-2.0"
 homepage: "https://github.com/ocurrent/ocluster"
 doc: "https://ocurrent.github.io/ocluster/"

--- a/ocluster.opam
+++ b/ocluster.opam
@@ -30,11 +30,11 @@ depends: [
   "dune" {>= "3.7"}
   "ocluster-api" {= version}
   "ocluster-worker" {= version}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.14.1"}
   "capnp-rpc-lwt" {>= "1.2.3"}
   "capnp-rpc-net" {>= "1.2.3"}
   "capnp-rpc-unix" {>= "1.2.3"}
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.2.0"}
   "conf-libev" {os != "win32"}
   "digestif" {>= "0.8"}
   "dune-build-info"

--- a/ocluster.opam
+++ b/ocluster.opam
@@ -12,7 +12,16 @@ At the moment, two build types are provided: building a Dockerfile, or building 
 In either case, the build may done in the context of some Git commit.
 The scheduler tries to schedule similar builds on the same machine, to benefit from caching."""
 maintainer: ["talex5@gmail.com"]
-authors: ["talex5@gmail.com"]
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
 license: "Apache-2.0"
 homepage: "https://github.com/ocurrent/ocluster"
 doc: "https://ocurrent.github.io/ocluster/"


### PR DESCRIPTION
Skip OBuilder's bash copy test on macOS (unsupported Docker backend).
Bump lower-bounds for Windows fixes.
List authors.