### PR TITLE
Fix fetcher

### DIFF
--- a/worker/fetcher.docker.ml
+++ b/worker/fetcher.docker.ml
@@ -1,1 +1,1 @@
-include Obuilder.Docker.Extract
+include Obuilder.Docker_extract

--- a/worker/obuilder_build.ml
+++ b/worker/obuilder_build.ml
@@ -42,7 +42,7 @@ let create ?prune_threshold ?prune_item_threshold ?prune_limit config =
   store >>= fun (Obuilder.Store_spec.Store ((module Store), store)) ->
   begin match sandbox_config with
   | `Native conf ->
-     let module Builder = Obuilder.Builder (Store) (Obuilder.Native_sandbox) (Obuilder.Docker_extract) in
+     let module Builder = Obuilder.Builder (Store) (Obuilder.Native_sandbox) (Fetcher) in
      Obuilder.Native_sandbox.create ~state_dir:(Store.state_dir store / "sandbox") conf >|= fun sandbox ->
      let builder = Builder.v ~store ~sandbox in
      Builder ((module Builder), builder)


### PR DESCRIPTION
The native fetcher should be `Fetcher` so that it pulls in either `fetcher.docker.ml` or `fetcher.macos.ml` based upon the Dune build rules.