### PR TITLE
Added basic Obuilder cache statistics to Prometheus

### DIFF
--- a/worker/obuilder_build.ml
+++ b/worker/obuilder_build.ml
@@ -139,3 +139,7 @@ let build t ~switch ~log ~spec ~src_dir ~secrets =
 let healthcheck t =
   let Builder ((module Builder), builder) = t.builder in
   Builder.healthcheck builder
+
+let cache_stats t =
+  let Builder ((module Builder), builder) = t.builder in
+  Builder.cache_stats builder

--- a/worker/obuilder_build.mli
+++ b/worker/obuilder_build.mli
@@ -18,3 +18,5 @@ val build : t ->
   secrets:(string * string) list -> (string, [ `Cancelled | `Msg of string ]) Lwt_result.t
 
 val healthcheck : t -> (unit, [> `Msg of string]) Lwt_result.t
+
+val cache_stats : t -> int * int


### PR DESCRIPTION
Adds `ocluster_worker_cache_hits` and `ocluster_worker_cache_misses` to Prometheus metrics provided by OCluster Worker.

Currently, this is deployed on `toxis` for testing.