### PR TITLE
Separate triggering and nontriggering Docker build arguments

### DIFF
--- a/api/docker.ml
+++ b/api/docker.ml
@@ -36,7 +36,8 @@ module Spec = struct
   }
 
   type options = {
-    build_args : string list;
+    triggering_build_args : string list;
+    nontriggering_build_args : string list;
     squash : bool;
     buildkit: bool;
     include_git : bool [@default true];
@@ -49,7 +50,8 @@ module Spec = struct
   }
 
   let defaults = {
-    build_args = [];
+    triggering_build_args = [];
+    nontriggering_build_args = [];
     squash = false;
     buildkit = false;
     include_git = false;
@@ -64,8 +66,9 @@ module Spec = struct
       | `Contents contents -> Dockerfile.contents_set dockerfile_b contents
       | `Path path -> Dockerfile.path_set dockerfile_b path
     end;
-    let { build_args; squash; buildkit; include_git } = options in
-    DB.build_args_set_list b build_args |> ignore;
+    let { triggering_build_args; nontriggering_build_args; squash; buildkit; include_git } = options in
+    DB.triggering_build_args_set_list b triggering_build_args |> ignore;
+    DB.nontriggering_build_args_set_list b nontriggering_build_args |> ignore;
     DB.squash_set b squash;
     DB.buildkit_set b buildkit;
     DB.include_git_set b include_git;
@@ -89,11 +92,12 @@ module Spec = struct
     let target = R.push_target_get r in
     let user = R.push_user_get r in
     let password = R.push_password_get r in
-    let build_args = R.build_args_get_list r in
+    let triggering_build_args = R.triggering_build_args_get_list r in
+    let nontriggering_build_args = R.nontriggering_build_args_get_list r in
     let squash = R.squash_get r in
     let buildkit = R.buildkit_get r in
     let include_git = R.include_git_get r in
-    let options = { build_args; squash; buildkit; include_git } in
+    let options = { triggering_build_args; nontriggering_build_args; squash; buildkit; include_git } in
     let push_to =
       match target, user, password with
       | "", "", "" -> None

--- a/api/docker.ml
+++ b/api/docker.ml
@@ -36,7 +36,7 @@ module Spec = struct
   }
 
   type options = {
-    triggering_build_args : string list;
+    build_args : string list;
     nontriggering_build_args : string list;
     squash : bool;
     buildkit: bool;
@@ -50,7 +50,7 @@ module Spec = struct
   }
 
   let defaults = {
-    triggering_build_args = [];
+    build_args = [];
     nontriggering_build_args = [];
     squash = false;
     buildkit = false;
@@ -66,8 +66,8 @@ module Spec = struct
       | `Contents contents -> Dockerfile.contents_set dockerfile_b contents
       | `Path path -> Dockerfile.path_set dockerfile_b path
     end;
-    let { triggering_build_args; nontriggering_build_args; squash; buildkit; include_git } = options in
-    DB.triggering_build_args_set_list b triggering_build_args |> ignore;
+    let { build_args; nontriggering_build_args; squash; buildkit; include_git } = options in
+    DB.build_args_set_list b build_args |> ignore;
     DB.nontriggering_build_args_set_list b nontriggering_build_args |> ignore;
     DB.squash_set b squash;
     DB.buildkit_set b buildkit;
@@ -92,12 +92,12 @@ module Spec = struct
     let target = R.push_target_get r in
     let user = R.push_user_get r in
     let password = R.push_password_get r in
-    let triggering_build_args = R.triggering_build_args_get_list r in
+    let build_args = R.build_args_get_list r in
     let nontriggering_build_args = R.nontriggering_build_args_get_list r in
     let squash = R.squash_get r in
     let buildkit = R.buildkit_get r in
     let include_git = R.include_git_get r in
-    let options = { triggering_build_args; nontriggering_build_args; squash; buildkit; include_git } in
+    let options = { build_args; nontriggering_build_args; squash; buildkit; include_git } in
     let push_to =
       match target, user, password with
       | "", "", "" -> None

--- a/api/docker.mli
+++ b/api/docker.mli
@@ -18,7 +18,7 @@ module Spec : sig
   }
 
   type options = {
-    triggering_build_args : string list; (** "--build-arg" arguments, changing these arguments triggers an OCurrent rebuild *)
+    build_args : string list; (** "--build-arg" arguments, changing these arguments triggers an OCurrent rebuild *)
     nontriggering_build_args : string list; (** Changing these arguments does not trigger a rebuild *)
     squash : bool;
     buildkit: bool;

--- a/api/docker.mli
+++ b/api/docker.mli
@@ -18,7 +18,8 @@ module Spec : sig
   }
 
   type options = {
-    build_args : string list;  (** "--build-arg" arguments. *)
+    triggering_build_args : string list; (** "--build-arg" arguments, changing these arguments triggers an OCurrent rebuild *)
+    nontriggering_build_args : string list; (** Changing these arguments does not trigger a rebuild *)
     squash : bool;
     buildkit: bool;
     include_git : bool;

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -21,10 +21,10 @@ struct DockerBuild {
   pushUser     @3 :Text;
   pushPassword @4 :Text;
 
-  triggeringBuildArgs    @5 :List(Text);
+  buildArgs    @5 :List(Text);
   nontriggeringBuildArgs    @6 :List(Text);
   # Options to pass to `docker build` using `--build-arg`.
-  # Triggering args trigger OCurrent rebuilds on changing, nontriggering args do not.
+  # buildArgs trigger OCurrent rebuilds on changing, nontriggeringBuildArgs do not.
 
   squash       @7 :Bool;
   # Squash the image layers together using `--squash`.

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -5,11 +5,11 @@ struct DockerBuild {
     contents   @0 :Text;
     # The contents of the Dockerfile to build.
 
-    path       @5 :Text;
+    path       @1 :Text;
     # The path of the Dockerfile within the context.
   }
 
-  pushTarget   @1 :Text;
+  pushTarget   @2 :Text;
   # If set, the builder will "docker push" to this target on success.
   # The format is "repo:tag". The tag is not optional.
   # You'll probably want to provide pushUser and pushPassword too when using this.
@@ -18,21 +18,23 @@ struct DockerBuild {
   # RepoId hash to tag it in the final repository yourself.
   # Example value: "myorg/staging:job-123"
 
-  pushUser     @2 :Text;
-  pushPassword @3 :Text;
+  pushUser     @3 :Text;
+  pushPassword @4 :Text;
 
-  buildArgs    @4 :List(Text);
+  triggeringBuildArgs    @5 :List(Text);
+  nontriggeringBuildArgs    @6 :List(Text);
   # Options to pass to `docker build` using `--build-arg`.
+  # Triggering args trigger OCurrent rebuilds on changing, nontriggering args do not.
 
-  squash       @6 :Bool;
+  squash       @7 :Bool;
   # Squash the image layers together using `--squash`.
 
-  buildkit     @7 :Bool;
+  buildkit     @8 :Bool;
   # Use BuildKit for the build.
   # Note: buildkit builds shared caches, so clients using such builds must all
   # trust each other not to poison the caches.
 
-  includeGit   @8 :Bool;
+  includeGit   @9 :Bool;
   # If set, include the .git directory in the build context.
 }
 

--- a/bin/client.ml
+++ b/bin/client.ml
@@ -192,13 +192,13 @@ let push_password_file =
     ~docv:"PATH"
     ["push-password"]
 
-let triggering_build_args =
+let build_args =
   Arg.value @@
   Arg.(opt_all string) [] @@
   Arg.info
     ~doc:"Docker build argument; triggers OCurrent rebuild on change."
     ~docv:"ARG"
-    ["build-arg"; "triggering-build-arg"]
+    ["build-arg"]
 
 let nontriggering_build_args =
   Arg.value @@
@@ -254,10 +254,10 @@ let push_to =
   Term.(const make $ push_to $ push_user $ push_password_file)
 
 let build_options =
-  let make triggering_build_args nontriggering_build_args squash buildkit include_git =
-    { Cluster_api.Docker.Spec.triggering_build_args; nontriggering_build_args; squash; buildkit; include_git }
+  let make build_args nontriggering_build_args squash buildkit include_git =
+    { Cluster_api.Docker.Spec.build_args; nontriggering_build_args; squash; buildkit; include_git }
   in
-  Term.(const make $ triggering_build_args $ nontriggering_build_args $ squash $ buildkit $ include_git)
+  Term.(const make $ build_args $ nontriggering_build_args $ squash $ buildkit $ include_git)
 
 let submit_options_common =
   let make submission_path pool repository commits cache_hint urgent secrets =

--- a/bin/client.ml
+++ b/bin/client.ml
@@ -192,13 +192,21 @@ let push_password_file =
     ~docv:"PATH"
     ["push-password"]
 
-let build_args =
+let triggering_build_args =
   Arg.value @@
   Arg.(opt_all string) [] @@
   Arg.info
-    ~doc:"Docker build argument."
+    ~doc:"Docker build argument; triggers OCurrent rebuild on change."
     ~docv:"ARG"
-    ["build-arg"]
+    ["build-arg"; "triggering-build-arg"]
+
+let nontriggering_build_args =
+  Arg.value @@
+  Arg.(opt_all string) [] @@
+  Arg.info
+    ~doc:"Docker build argument; doesn't trigger OCurrent rebuild on change."
+    ~docv:"ARG"
+    ["nontriggering-build-arg"]
 
 let secrets =
   (Arg.value @@
@@ -246,10 +254,10 @@ let push_to =
   Term.(const make $ push_to $ push_user $ push_password_file)
 
 let build_options =
-  let make build_args squash buildkit include_git =
-    { Cluster_api.Docker.Spec.build_args; squash; buildkit; include_git }
+  let make triggering_build_args nontriggering_build_args squash buildkit include_git =
+    { Cluster_api.Docker.Spec.triggering_build_args; nontriggering_build_args; squash; buildkit; include_git }
   in
-  Term.(const make $ build_args $ squash $ buildkit $ include_git)
+  Term.(const make $ triggering_build_args $ nontriggering_build_args $ squash $ buildkit $ include_git)
 
 let submit_options_common =
   let make submission_path pool repository commits cache_hint urgent secrets =

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -409,7 +409,8 @@ let default_build ?obuilder ~switch ~log ~src ~secrets = function
              | Ok path -> Lwt_result.return path
              | Error e -> Lwt_result.fail e
          end >>!= fun dockerpath ->
-         let { Cluster_api.Docker.Spec.build_args; squash; buildkit; include_git = _ } = options in
+         let { Cluster_api.Docker.Spec.triggering_build_args; nontriggering_build_args; squash; buildkit; include_git = _ } = options in
+         let build_args = triggering_build_args @ nontriggering_build_args in
          let args =
            List.concat_map (fun x -> ["--build-arg"; x]) build_args
            @ (if squash then ["--squash"] else [])

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -409,8 +409,8 @@ let default_build ?obuilder ~switch ~log ~src ~secrets = function
              | Ok path -> Lwt_result.return path
              | Error e -> Lwt_result.fail e
          end >>!= fun dockerpath ->
-         let { Cluster_api.Docker.Spec.triggering_build_args; nontriggering_build_args; squash; buildkit; include_git = _ } = options in
-         let build_args = triggering_build_args @ nontriggering_build_args in
+         let { Cluster_api.Docker.Spec.build_args; nontriggering_build_args; squash; buildkit; include_git = _ } = options in
+         let build_args = build_args @ nontriggering_build_args in
          let args =
            List.concat_map (fun x -> ["--build-arg"; x]) build_args
            @ (if squash then ["--squash"] else [])


### PR DESCRIPTION
As requested in https://github.com/tarides/infrastructure/issues/285, sometimes we would like to have build argument inputs that, when changed, do not trigger a rebuild. This is useful for a staging environment vs a live environment.

However, specifying only Docker build args as triggering or nontriggering is very use-case-specific. Ideally we would have a more streamlined way to specify *all* inputs as either triggering or nontriggering, but this would require quite a bit of refactoring.

This is a breaking change; at the very least `ocurrent-deployer` will have to be modified as well.