### PR TITLE
Purge Obuilder Docker store when Docker is pruned

### DIFF
--- a/worker/context.ml
+++ b/worker/context.ml
@@ -197,7 +197,7 @@ let build_context t ~log ~tmpdir descr =
         if include_git descr then (
           let cmd, is_success =
             if Sys.win32 then
-              ["robocopy"; clone / ".git"; tmpdir / ".git"; "/COPY:DATSO"; "/E"; "/R:0"; "/DCOPY:T"],
+              ["robocopy"; clone / ".git"; tmpdir / ".git"; "/COPY:DATSO"; "/E"; "/R:0"; "/DCOPY:T"; "/NDL"; "/NFL"],
               fun s -> s = 1
             else
               ["cp"; "-a"; clone / ".git"; tmpdir / ".git"],

--- a/worker/obuilder_build.mli
+++ b/worker/obuilder_build.mli
@@ -20,3 +20,7 @@ val build : t ->
 val healthcheck : t -> (unit, [> `Msg of string]) Lwt_result.t
 
 val cache_stats : t -> int * int
+
+val purge : t -> int Lwt.t
+
+val backend : t -> [`Native of Obuilder.Native_sandbox.config | `Docker of Obuilder.Docker_sandbox.config ]


### PR DESCRIPTION
When docker is pruned, everything is deleted from Obuilder Docker store.  However, obuilder does not know this has happened so the database is out of sync.