### PR TITLE
Async delete

### DIFF
--- a/test/mock_builder.ml
+++ b/test/mock_builder.ml
@@ -90,14 +90,14 @@ let update () =
   Lwt.return (fun () -> failwith "Mock restart")
 
 let run ?(capacity=1) ?(name="worker-1") ~switch t registration_service =
-  let thread = Cluster_worker.run ~switch ~capacity ~name ~build:(build t) ~healthcheck_period:600.0 ~update ~state_dir registration_service in
+  let thread = Cluster_worker.run ~switch ~capacity ~name ~build:(build t) ~update ~state_dir registration_service in
   Lwt.on_failure thread
     (fun ex -> if Lwt_switch.is_on switch then raise ex)
 
 let run_remote ~builder_switch ~network_switch ?(capacity=1) ?(name="worker-1") t registration_service =
   let thread =
     let registration_service = Mock_network.remote ~switch:network_switch registration_service in
-    Cluster_worker.run ~switch:builder_switch ~capacity ~name ~build:(build t) ~healthcheck_period:600.0 ~update ~state_dir registration_service
+    Cluster_worker.run ~switch:builder_switch ~capacity ~name ~build:(build t) ~update ~state_dir registration_service
   in
   Lwt.on_failure thread
     (fun ex ->

--- a/worker/cluster_worker.mli
+++ b/worker/cluster_worker.mli
@@ -21,11 +21,10 @@ val run :
   ?switch:Lwt_switch.t ->
   ?build:build ->
   ?allow_push:string list ->
-  healthcheck_period:float ->
+  ?healthcheck_period:float ->
   ?prune_threshold:float ->
   ?docker_max_df_size:float ->
   ?obuilder_prune_threshold:float ->
-  ?obuilder_prune_item_threshold:int64 ->
   ?obuilder_prune_limit:int ->
   ?obuilder:Obuilder_config.t ->
   ?additional_metrics:(string * Uri.t) list ->

--- a/worker/dune
+++ b/worker/dune
@@ -13,4 +13,4 @@
 (library
  (name cluster_worker)
  (public_name ocluster-worker)
- (libraries ocluster-api digestif fpath logs capnp-rpc-lwt lwt.unix prometheus-app cohttp-lwt-unix obuilder extunix))
+ (libraries ocluster-api digestif fpath logs capnp-rpc-lwt lwt.unix prometheus-app cohttp-lwt-unix obuilder extunix str))

--- a/worker/metrics.ml
+++ b/worker/metrics.ml
@@ -1,0 +1,45 @@
+open Prometheus
+
+let namespace = "ocluster"
+let subsystem = "worker"
+
+let jobs_accepted =
+  let help = "Number of jobs accepted in total" in
+  Counter.v ~help ~namespace ~subsystem "jobs_accepted_total"
+
+let job_time =
+  let help = "Time jobs ran for" in
+  Summary.v_label ~label_name:"result" ~help ~namespace ~subsystem "job_time_seconds"
+
+let docker_push_time =
+  let help = "Time uploading to Docker Hub" in
+  Summary.v ~help ~namespace ~subsystem "docker_push_time_seconds"
+
+let docker_prune_time =
+  let help = "Time spent pruning Docker cache" in
+  Summary.v ~help ~namespace ~subsystem "docker_prune_time_seconds"
+
+let running_jobs =
+  let help = "Number of jobs currently running" in
+  Gauge.v ~help ~namespace ~subsystem "running_jobs"
+
+let healthcheck_time =
+  let help = "Time to perform last healthcheck" in
+  Gauge.v ~help ~namespace ~subsystem "healthcheck_time_seconds"
+
+let unhealthy =
+  let help = "Number of unhealthy workers" in
+  Gauge.v ~help ~namespace ~subsystem "unhealthy"
+
+let cache_hits =
+  let help = "Number of OBuilder cache hits" in
+  Gauge.v ~help ~namespace ~subsystem "cache_hits"
+
+let cache_misses =
+  let help = "Number of OBuilder cache misses" in
+  Gauge.v ~help ~namespace ~subsystem "cache_misses"
+
+let obuilder_space_free =
+  let help = "OBuilder percentage of space free" in
+  Gauge.v ~help ~namespace ~subsystem "obuilder_space_free"
+

--- a/worker/obuilder_build.ml
+++ b/worker/obuilder_build.ml
@@ -1,7 +1,5 @@
 open Lwt.Infix
 
-let prune_margin = 600.0        (* Don't prune anything used less than 10 minutes ago *)
-
 type builder = Builder : (module Obuilder.BUILDER with type t = 'a) * 'a -> builder
 
 module Config = struct
@@ -18,9 +16,6 @@ type t = {
   builder : builder;
   mutable pruning : bool;
   cond : unit Lwt_condition.t;          (* Fires when we finish pruning *)
-  prune_threshold : float option;
-  prune_item_threshold : int64 option;  (* Threshold number of items to hold in obuilder store *)
-  prune_limit : int option;             (* Number of items to prune from obuilder when threshold is reached *)
 }
 
 let ( / ) = Filename.concat
@@ -37,7 +32,7 @@ let log_to log_data tag msg =
   | `Note -> Log_data.info log_data "\027[01;2m\027[01;35m%a %s\027[0m" pp_timestamp (Unix.gettimeofday ()) msg
   | `Output -> Log_data.write log_data msg
 
-let create ?prune_threshold ?prune_item_threshold ?prune_limit config =
+let create ?(prune_threshold = 30.0) ?(prune_limit = 100) config =
   let { Config.store; sandbox_config } = config in
   store >>= fun (Obuilder.Store_spec.Store ((module Store), store)) ->
   begin match sandbox_config with
@@ -58,79 +53,36 @@ let create ?prune_threshold ?prune_item_threshold ?prune_limit config =
   | Error (`Msg m) -> Fmt.failwith "Initial OBuilder healthcheck failed: %s" m
   | Ok () ->
     Log.info (fun f -> f "OBuilder self-test passed");
+    let r =
     {
       builder = Builder ((module Builder), builder);
       pruning = false;
-      prune_threshold;
-      prune_item_threshold;
-      prune_limit;
       cond = Lwt_condition.create ();
-    }
-
-(* Prune [t] until free space rises above [prune_threshold]
-   or number of items falls below [prune_item_threshold]. *)
-let do_prune ~prune_threshold ~prune_item_threshold ~prune_limit t =
-  let Builder ((module Builder), builder) = t.builder in
-  let rec aux () =
-    let stop = Unix.gettimeofday () -. prune_margin |> Unix.gmtime in
-    Builder.prune builder ~before:stop prune_limit >>= fun n ->
-    Builder.df builder >>= fun free ->
-    let count = Builder.count builder in
-    Log.info (fun f -> f "OBuilder partition: %.0f%% free, %Li items after pruning %d items" free count n);
-    if free > prune_threshold && count < prune_item_threshold
-    then Lwt.return_unit      (* Space problem is fixed! *)
-    else if n < prune_limit then (
-      Log.warn (fun f -> f "Out of space, but nothing left to prune! (will wait and then retry)");
-      Lwt_unix.sleep 600.0 >>= aux
-    ) else (
-      (* Continue pruning *)
-      aux ()
-    )
-  in
-  aux ()
-
-(* Check the free space and/or number of items in [t]'s store.
-   If less than [t.prune_threshold] or items > [t.prune_item_threshold], spawn a prune operation (if not already running).
-   If less than half that is remaining, also wait for it to finish.
-   Returns once there is enough free space to proceed. *)
-let check_free_space t =
-  let prune_limit = Option.value t.prune_limit ~default:100 in
-  let prune_threshold = Option.value t.prune_threshold ~default:0. in
-  let prune_item_threshold = Option.value t.prune_item_threshold ~default:Int64.max_int in
-  if prune_threshold = 0. && prune_item_threshold = Int64.max_int then
-    Lwt.return_unit (* No limits have been set *)
-  else
-    let Builder ((module Builder), builder) = t.builder in
-    let rec aux () =
-      Builder.df builder >>= fun free ->
-      let count = Builder.count builder in
-      Log.info (fun f -> f "OBuilder partition: %.0f%% free, %Li items" free count);
-      (* If we're low on space, or over the threshold number of items spawn a pruning thread. *)
-      if ((prune_threshold > 0. && free < prune_threshold) ||
-          (prune_item_threshold < Int64.max_int && count > prune_item_threshold)) && not t.pruning then (
-        t.pruning <- true;
-        Lwt.async (fun () ->
-            Lwt.finalize
-              (fun () -> do_prune ~prune_threshold ~prune_item_threshold ~prune_limit t)
-              (fun () ->
-                 Lwt.pause () >|= fun () ->
-                 t.pruning <- false;
-                 Lwt_condition.broadcast t.cond ()
-              )
-          );
-      );
-      if free < prune_threshold /. 2.0 then (
-        assert (t.pruning);
-        Log.info (fun f -> f "OBuilder space very low. Waiting for prune to finish…");
-        Lwt_condition.wait t.cond >>= aux
-      ) else (
-        Lwt.return_unit
-      )
-    in
-    aux ()
+    } in
+    Lwt.async (fun () ->
+      let rec loop () =
+        Builder.df builder >>= fun free ->
+        let count = Builder.count builder in
+        Log.info (fun f -> f "OBuilder partition: %.0f%% free, %Li items" free count);
+        Prometheus.Gauge.set Metrics.obuilder_space_free free;
+        if free > prune_threshold then (
+          r.pruning <- false;
+          Lwt_condition.signal r.cond (); (* release one waiting process *)
+          Lwt_unix.sleep 30.0 >>= fun () -> loop ()
+        ) else (
+          r.pruning <- true;
+          let stop = Unix.gettimeofday () |> Unix.gmtime in
+          Builder.prune builder ~before:stop prune_limit >>= fun n ->
+          Log.info (fun f -> f "Pruned %i items" n);
+          (if n = 0 then Lwt_unix.sleep 30.0
+          else Lwt.return_unit )>>= fun () -> loop ()
+        )
+      in loop ()
+    ); r
 
 let build t ~switch ~log ~spec ~src_dir ~secrets =
-  check_free_space t >>= fun () ->
+  (if t.pruning then Lwt_condition.wait t.cond
+  else Lwt.return ()) >>= fun () ->
   let log = log_to log in
   let context = Obuilder.Context.v ~switch ~log ~src_dir ~secrets () in
   let Builder ((module Builder), builder) = t.builder in

--- a/worker/obuilder_build.mli
+++ b/worker/obuilder_build.mli
@@ -8,7 +8,7 @@ module Config : sig
           -> Obuilder.Store_spec.store Lwt.t -> t
 end
 
-val create : ?prune_threshold:float -> ?prune_item_threshold:int64 -> ?prune_limit:int -> Config.t -> t Lwt.t
+val create : ?prune_threshold:float -> ?prune_limit:int -> Config.t -> t Lwt.t
 
 val build : t ->
   switch:Lwt_switch.t ->


### PR DESCRIPTION
Changes:
* Prune is now an asynchronous thread which checks free space every 30 seconds rather than just between jobs.  This proved essential for overlayfs/tmpfs where disk space is typically smaller and consumed much more quickly.
* `obuilder_prune_item_threshold` was removed - I added this for macOS, but it turned out to be unnecessary.
* Moved metrics code into a `metrics.ml`.
* Added a rudimentary weighting of larger jobs based upon regex matches of the cache hint.