### PR TITLE
Retry on failed docker push

### DIFF
--- a/lwt_retry/dune
+++ b/lwt_retry/dune
@@ -1,0 +1,5 @@
+(library
+ (name        lwt_retry)
+ (libraries   lwt lwt.unix)
+ (synopsis "A utility for retrying Lwt computations")
+ (package ocluster-worker))

--- a/lwt_retry/lwt_retry.ml
+++ b/lwt_retry/lwt_retry.ml
@@ -1,0 +1,65 @@
+open Lwt.Syntax
+
+let default_sleep_duration n' =
+  let base_sleep_time = 2.0 in
+  let n = Int.to_float n' in
+  n *. base_sleep_time *. Float.pow 1.5 n
+
+type ('retry, 'fatal) error =
+  [ `Retry of 'retry
+  | `Fatal of 'fatal
+  ]
+
+let pp_opaque fmt _ = Format.fprintf fmt "<opaque>"
+
+let pp_error ?(retry = pp_opaque) ?(fatal = pp_opaque) fmt err =
+  match err with
+  | `Retry r -> Format.fprintf fmt "`Retry %a" retry r
+  | `Fatal f -> Format.fprintf fmt "`Fatal %a" fatal f
+
+let equal_error ~retry ~fatal a b =
+  match a, b with
+  | `Retry a', `Retry b' -> retry a' b'
+  | `Fatal a', `Fatal b' -> fatal a' b'
+  | _ -> false
+
+type ('ok, 'retry, 'fatal) attempt = ('ok, ('retry, 'fatal) error) result
+
+let is_retryable = function
+  | Error (`Retry _) -> true
+  | _ -> false
+
+let on_error
+    (f : unit -> ('ok, 'retry, 'fatal) attempt Lwt.t)
+  : ('ok, 'retry, 'fatal) attempt Lwt_stream.t
+  =
+  let stop = ref false in
+  let attempt () =
+    if !stop then
+      Lwt.return_none
+    else
+      let+ result = f () in
+      stop := not (is_retryable result);
+      Some result
+  in
+  Lwt_stream.from attempt
+
+let numbered attempts : (int * _) Lwt_stream.t =
+  let i = ref 0 in
+  let indexes = Lwt_stream.from_direct (fun () -> let n = !i in incr i; Some n) in
+  Lwt_stream.combine indexes attempts
+
+let with_sleep ?(duration=default_sleep_duration) attempts =
+  attempts
+  |> numbered
+  |> Lwt_stream.map_s (fun (attempt_number, attempt_result) ->
+      let+ () = Lwt_unix.sleep @@ duration attempt_number in
+      attempt_result)
+
+let n_times n attempts =
+  (* The first attempt is a try, and REtries start counting from n + 1 *)
+  let retries = n + 1 in
+  let+ attempts = Lwt_stream.nget retries attempts in
+  match List.rev attempts with
+  | last :: _ -> last
+  | _ -> failwith "impossible"

--- a/lwt_retry/lwt_retry.ml
+++ b/lwt_retry/lwt_retry.ml
@@ -3,7 +3,7 @@ open Lwt.Syntax
 let default_sleep_duration n' =
   let base_sleep_time = 2.0 in
   let n = Int.to_float n' in
-  n *. base_sleep_time *. Float.pow 1.5 n
+  n *. base_sleep_time *. Float.pow 2.0 n
 
 type ('retry, 'fatal) error =
   [ `Retry of 'retry

--- a/lwt_retry/lwt_retry.mli
+++ b/lwt_retry/lwt_retry.mli
@@ -1,0 +1,121 @@
+(** Utilities for retrying Lwt computations *)
+
+(* NOTE: We expect this library to be useful in other parts of the ocurrent
+   stack, but this is where we need it first. Please promote this to more  a
+   more general, shared location when needed, instead of copying the code. *)
+
+type ('retry, 'fatal) error =
+  [ `Retry of 'retry
+  | `Fatal of 'fatal
+  ]
+(** The type of errors that a retryable computation can produce.
+
+    - [`Retry r] when [r] represents an error that can be retried.
+    - [`Fatal f] when [f] represents an error that cannot be retried. *)
+
+type ('ok, 'retry, 'fatal) attempt = ('ok, ('retry, 'fatal) error) result
+(** A [('ok, 'retry, 'fatal) attempt] is an alias for the [result] of a
+    retryable computation.
+
+    - [Ok v] produces a successful value [v]
+    - [Error err] produces the {!type:error} [err] *)
+
+val pp_error :
+  ?retry:(Format.formatter -> 'retry -> unit) ->
+  ?fatal:(Format.formatter -> 'fatal -> unit) ->
+  Format.formatter -> ('retry, 'fatal) error -> unit
+(** [pp_error ~retry ~fatal] is a formatter for {!type:error}s that formats
+    fatal and retryable errors according to the provided formatters.
+
+    If either formatter is not provided, a default formatter will represent the
+    values as ["<opaque>"]. *)
+
+val equal_error :
+  retry:('retry -> 'retry -> bool) ->
+  fatal:('fatal -> 'fatal -> bool) ->
+  ('retry, 'fatal) error ->
+  ('retry, 'fatal) error ->
+  bool
+
+val on_error :
+  (unit -> ('ok, 'retry, 'fatal) attempt Lwt.t) ->
+  ('ok, 'retry, 'fatal) attempt Lwt_stream.t
+(** [on_error f] is a stream of attempts to compute [f]. The stream will continue until
+    the computation succeeds or produces a fatal error.
+
+    Examples
+
+    {[
+      # let success () = Lwt.return_ok ();;
+      val success : unit -> (unit, 'a) result Lwt.t = <fun>
+      # Lwt_retry.(success |> on_error) |> Lwt_stream.to_list;;
+      - : (unit, 'a, 'b) Lwt_retry.attempt list = [Ok ()]
+
+      # let fatal_failure () = Lwt.return_error (`Fatal ());;
+      val fatal_failure : unit -> ('a, [> `Fatal of unit ]) result Lwt.t = <fun>
+      # Lwt_retry.(fatal_failure |> on_error) |> Lwt_stream.to_list;;
+      - : ('a, 'b, unit) Lwt_retry.attempt list = [Error (`Fatal ())]
+
+      # let retryable_error () = Lwt.return_error (`Retry ());;
+      val retryable_error : unit -> ('a, [> `Retry of unit ]) result Lwt.t = <fun>
+      # Lwt_retry.(retryable_error |> on_error) |> Lwt_stream.nget 3;;
+      - : ('a, unit, 'b) Lwt_retry.attempt list =
+      [Error (`Retry ()); Error (`Retry ()); Error (`Retry ())]
+    ]}*)
+
+val with_sleep :
+  ?duration:(int -> float) ->
+  ('ok, 'retry, 'fatal) attempt Lwt_stream.t ->
+  ('ok, 'retry, 'fatal) attempt Lwt_stream.t
+(** [with_sleep ~duration attempts] is the stream of [attempts] with a sleep
+    added after computing each [n]th retryable attempt based on [duration n].
+
+    @param duration the optional sleep duration. This defaults to an exponential
+    backoff computed as n * 2 * (1.5 ^ n), which gives the approximate sequence
+    0s -> 3s -> 9s -> 20.25 -> 40.5s -> 75.9s -> 136.7 -> ...
+
+    Examples
+    {[
+      # let f () = Lwt.return_error (`Retry ());;
+      # let attempts_with_sleeps = Lwt_retry.(f |> on_error |> with_sleep);;
+
+      # Lwt_stream.get attempts_with_sleeps;;
+      (* computed immediately *)
+      Some (Error (`Retry ()))
+
+      # Lwt_stream.get attempts_with_sleeps;;
+      (* computed after 3 seconds *)
+      Some (Error (`Retry ()))
+
+      # Lwt_stream.get attempts_with_sleeps;;
+      (* computed after 9 seconds *)
+      Some (Error (`Retry ()))
+
+      (* a stream with a constant 1s sleep between attempts *)
+      # let attempts_with_constant_sleeps =
+          Lwt_retry.(f |> on_error |> with_sleep ~duration:(fun _ -> 1.0));;
+    ]} *)
+
+val n_times :
+  int ->
+  ('ok, 'retry, 'fatal) attempt Lwt_stream.t ->
+  ('ok, ('retry, 'fatal) error) result Lwt.t
+(** [n_times n attempts] is [Ok v] if one of the [attempts] succeeds within [n]
+    retries (or [n+1] attempts), [Error (`Fatal f)] if any of the attempts
+    results in the fatal error, or [Error (`Retry r)] if all [n] retries are
+    exhausted, with the [n+1]th attempt resulting in the retry error.
+
+    In particular [n_times 0 attempts] will *try* 1 attempt but *retry* 0, so it
+    is guaranteed to produce some result.
+
+    Examples
+
+    {[
+      # let f () =
+          let i = ref 0 in
+          fun () -> Lwt.return_error (if !i < 3 then (incr i; `Retry !i) else `Fatal "error!");;
+      # Lwt_retry.(f () |> on_error |> n_times 0);;
+      Error (`Retry 1)
+      # Lwt_retry.(f () |> on_error |> n_times 4);;
+      Error (`Fatal "error!")
+    ]} *)

--- a/lwt_retry/lwt_retry.mli
+++ b/lwt_retry/lwt_retry.mli
@@ -71,8 +71,8 @@ val with_sleep :
     added after computing each [n]th retryable attempt based on [duration n].
 
     @param duration the optional sleep duration. This defaults to an exponential
-    backoff computed as n * 2 * (1.5 ^ n), which gives the approximate sequence
-    0s -> 3s -> 9s -> 20.25 -> 40.5s -> 75.9s -> 136.7 -> ...
+    backoff computed as n * 2 * (2 ^ n), which gives the sequence
+    [ [0.; 4.; 16.; 48.; 128.; 320.; 768.; 1792.; ...] ].
 
     Examples
     {[

--- a/lwt_retry/lwt_retry.mli
+++ b/lwt_retry/lwt_retry.mli
@@ -13,12 +13,13 @@ type ('retry, 'fatal) error =
     - [`Retry r] when [r] represents an error that can be retried.
     - [`Fatal f] when [f] represents an error that cannot be retried. *)
 
-type ('ok, 'retry, 'fatal) attempt = ('ok, ('retry, 'fatal) error) result
-(** A [('ok, 'retry, 'fatal) attempt] is an alias for the [result] of a
-    retryable computation.
+type ('ok, 'retry, 'fatal) attempt = ('ok, ('retry, 'fatal) error * int) result
+(** A [('ok, 'retry, 'fatal) attempt] is the [result] of a retryable computation
+    the erroneous results enumerated.
 
-    - [Ok v] produces a successful value [v]
-    - [Error err] produces the {!type:error} [err] *)
+    - [Ok v] is a successfully computed value [v]
+    - [Error (err, n)] is the {!type:error} [err] produced on the [n]th
+      attempt *)
 
 val pp_error :
   ?retry:(Format.formatter -> 'retry -> unit) ->
@@ -38,9 +39,9 @@ val equal_error :
   bool
 
 val on_error :
-  (unit -> ('ok, 'retry, 'fatal) attempt Lwt.t) ->
+  (unit -> ('ok, ('retry, 'fatal) error) result Lwt.t) ->
   ('ok, 'retry, 'fatal) attempt Lwt_stream.t
-(** [on_error f] is a stream of attempts to compute [f]. The stream will continue until
+(** [Lwt_retry.on_error f] is a stream of attempts to compute [f]. The stream will continue until
     the computation succeeds or produces a fatal error.
 
     Examples
@@ -54,14 +55,21 @@ val on_error :
       # let fatal_failure () = Lwt.return_error (`Fatal ());;
       val fatal_failure : unit -> ('a, [> `Fatal of unit ]) result Lwt.t = <fun>
       # Lwt_retry.(fatal_failure |> on_error) |> Lwt_stream.to_list;;
-      - : ('a, 'b, unit) Lwt_retry.attempt list = [Error (`Fatal ())]
+      - : ('a, 'b, unit) Lwt_retry.attempt list = [Error (`Fatal (), 1)]
 
       # let retryable_error () = Lwt.return_error (`Retry ());;
       val retryable_error : unit -> ('a, [> `Retry of unit ]) result Lwt.t = <fun>
       # Lwt_retry.(retryable_error |> on_error) |> Lwt_stream.nget 3;;
       - : ('a, unit, 'b) Lwt_retry.attempt list =
-      [Error (`Retry ()); Error (`Retry ()); Error (`Retry ())]
+      [Error (`Retry (), 1); Error (`Retry (), 2); Error (`Retry (), 3)]
     ]}*)
+
+val map_retry :
+  ('retry -> int -> 'a) ->
+  ('ok, 'retry, 'fatal) attempt Lwt_stream.t ->
+  ('ok, 'a, 'fatal) attempt Lwt_stream.t
+(** [map_retry f attempts] is a stream of attempts with the outcome of any retryable
+    attempt [Error (`Retry r, n)] mapped to [Error (`Retry (f r n), n)] *)
 
 val with_sleep :
   ?duration:(int -> float) ->
@@ -70,52 +78,57 @@ val with_sleep :
 (** [with_sleep ~duration attempts] is the stream of [attempts] with a sleep
     added after computing each [n]th retryable attempt based on [duration n].
 
-    @param duration the optional sleep duration. This defaults to an exponential
-    backoff computed as n * 2 * (2 ^ n), which gives the sequence
-    [ [0.; 4.; 16.; 48.; 128.; 320.; 768.; 1792.; ...] ].
+    @param duration the optional sleep duration, defaulting to
+    {!val:default_sleep_duration}.
 
     Examples
+
     {[
       # let f () = Lwt.return_error (`Retry ());;
       # let attempts_with_sleeps = Lwt_retry.(f |> on_error |> with_sleep);;
 
       # Lwt_stream.get attempts_with_sleeps;;
       (* computed immediately *)
-      Some (Error (`Retry ()))
+      Some (Error (`Retry (), 1))
 
       # Lwt_stream.get attempts_with_sleeps;;
       (* computed after 3 seconds *)
-      Some (Error (`Retry ()))
+      Some (Error (`Retry (), 2))
 
       # Lwt_stream.get attempts_with_sleeps;;
       (* computed after 9 seconds *)
-      Some (Error (`Retry ()))
+      Some (Error (`Retry (), 3))
 
       (* a stream with a constant 1s sleep between attempts *)
       # let attempts_with_constant_sleeps =
           Lwt_retry.(f |> on_error |> with_sleep ~duration:(fun _ -> 1.0));;
     ]} *)
 
+val default_sleep_duration : int -> float
+(** [default_sleep_duration n] is an exponential backoff computed as [n] * 2 *
+    (2 ^ [n]), which gives the sequence [ [0.; 4.; 16.; 48.; 128.; 320.; 768.;
+    1792.; ...] ]. *)
+
 val n_times :
   int ->
   ('ok, 'retry, 'fatal) attempt Lwt_stream.t ->
-  ('ok, ('retry, 'fatal) error) result Lwt.t
+  ('ok, 'retry, 'fatal) attempt Lwt.t
 (** [n_times n attempts] is [Ok v] if one of the [attempts] succeeds within [n]
-    retries (or [n+1] attempts), [Error (`Fatal f)] if any of the attempts
-    results in the fatal error, or [Error (`Retry r)] if all [n] retries are
-    exhausted, with the [n+1]th attempt resulting in the retry error.
+    retries (or [n+1] attempts), [Error (`Fatal f, n+1)] if any of the attempts
+    results in the fatal error, or [Error (`Retry r, n+1)] if all [n] retries are
+    exhausted and the [n+1]th attempt results in a retry error.
 
-    In particular [n_times 0 attempts] will *try* 1 attempt but *retry* 0, so it
-    is guaranteed to produce some result.
+    In particular [n_times 0 attempts] will *try* 1 attempt but *re-try* 0, so
+    it is guaranteed to produce some result.
 
     Examples
 
     {[
       # let f () =
           let i = ref 0 in
-          fun () -> Lwt.return_error (if !i < 3 then (incr i; `Retry !i) else `Fatal "error!");;
+          fun () -> Lwt.return_error (if !i < 3 then (incr i; `Retry ()) else `Fatal "error!");;
       # Lwt_retry.(f () |> on_error |> n_times 0);;
-      Error (`Retry 1)
+      Error (`Retry (), 1)
       # Lwt_retry.(f () |> on_error |> n_times 4);;
-      Error (`Fatal "error!")
+      Error (`Fatal "error!", 3)
     ]} *)

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,7 @@
 (test
   (name test)
   (package ocluster)
-  (modules test custom mock_builder mock_network test_plugin)
+  (modules test custom mock_builder mock_network test_plugin test_lwt_retry)
   (libraries
     alcotest-lwt
     capnp-rpc-net
@@ -9,6 +9,7 @@
     cluster_scheduler
     cluster_worker
     current_ocluster
+    lwt_retry
     db
     fmt.tty
     logs.fmt

--- a/test/test.ml
+++ b/test/test.ml
@@ -509,5 +509,6 @@ let () =
         test_case "clients" clients;
       ];
       "plugin", Test_plugin.suite;
+      "lwt_retry", Test_lwt_retry.suite;
     ]
   end

--- a/test/test_lwt_retry.ml
+++ b/test/test_lwt_retry.ml
@@ -1,0 +1,183 @@
+open Lwt.Infix
+open Lwt.Syntax
+
+module Retry = Lwt_retry
+
+let attempt
+    (ok : 'ok Alcotest.testable)
+    (retry : 'retry Alcotest.testable)
+    (fatal : 'fatal Alcotest.testable)
+  : ('ok, 'retry, 'fatal) Retry.attempt Alcotest.testable
+  =
+  let pp = Retry.pp_error
+      ~retry:(Alcotest.pp retry)
+      ~fatal:(Alcotest.pp fatal)
+  in
+  let eq = Retry.equal_error
+      ~retry:(Alcotest.equal retry)
+      ~fatal:(Alcotest.equal fatal)
+  in
+  let error = Alcotest.testable pp eq in
+  Alcotest.result ok error
+
+let attempt_u = Alcotest.(attempt unit unit unit)
+
+let test_pp_error _switch () =
+  let pp = Retry.pp_error ~retry:Format.pp_print_float ~fatal:Format.pp_print_int in
+  Lwt.return begin
+    Alcotest.(check' string)
+      ~msg:"can format retries outcomes"
+      ~expected:"`Retry 3."
+      ~actual:(Format.asprintf "%a" pp (`Retry 3.0));
+    Alcotest.(check' string)
+      ~msg:"can format fatal outcomes"
+      ~expected:"`Fatal 42"
+      ~actual:(Format.asprintf "%a" pp (`Fatal 42));
+    Alcotest.(check' string)
+      ~msg:"can format with default printer"
+      ~expected:"`Fatal <opaque>"
+      ~actual:(Format.asprintf "%a" (fun x -> Retry.pp_error x) (`Fatal 42))
+  end
+
+let test_success_without_retry _switch () =
+  let strm =
+    Retry.on_error (fun () -> Lwt.return_ok 42)
+  in
+
+  let msg = "expected success" in
+  let expected = (Ok 42) in
+  let* actual = Lwt_stream.next strm in
+  Alcotest.(check' (attempt int unit unit)) ~msg ~expected ~actual;
+
+  let msg = "expected stream to be empty" in
+  let expected = true in
+  let+ actual = Lwt_stream.is_empty strm in
+  Alcotest.(check' bool) ~msg ~expected ~actual
+
+let test_retries _switch () =
+  let strm =
+    Retry.on_error (fun () -> Lwt.return_error (`Retry ()))
+  in
+
+  let msg = "expected 3 retry errors" in
+  let expected = List.init 3 (fun _ -> Error (`Retry ())) in
+  let+ actual = Lwt_stream.nget 3 strm in
+  Alcotest.(check' (list attempt_u)) ~msg ~expected ~actual
+
+let test_retries_before_fatal_error _switch () =
+  let retries_before_fatal = 3 in
+  let i = ref 0 in
+  let strm = Retry.on_error
+      (fun () ->
+         if !i < retries_before_fatal then (
+           incr i;
+           Lwt.return_error (`Retry ())
+         ) else
+           Lwt.return_error (`Fatal ()))
+  in
+
+  let msg = "expected 3 retry errors" in
+  let expected = retries_before_fatal in
+  let* actual = Lwt_stream.nget retries_before_fatal strm >|= List.length in
+  Alcotest.(check' int) ~msg ~expected ~actual;
+
+  let msg = "expected fatal error" in
+  let expected = Error (`Fatal ()) in
+  let* actual = Lwt_stream.next strm in
+  Alcotest.(check' attempt_u) ~msg ~expected ~actual;
+
+  let msg = "expected stream to be empty" in
+  let+ stream_is_empty = Lwt_stream.is_empty strm in
+  Alcotest.(check' bool) ~msg ~expected:true ~actual:stream_is_empty
+
+let test_retries_before_success _switch () =
+  let retries_before_fatal = 3 in
+  let i = ref 0 in
+  let strm = Retry.on_error (fun () ->
+      if !i < retries_before_fatal then (
+        incr i;
+        Lwt.return_error (`Retry ())
+      ) else
+        Lwt.return_ok ()
+    )
+  in
+
+  let msg = "expected 3 retry errors" in
+  let expected = retries_before_fatal in
+  let* actual = Lwt_stream.nget retries_before_fatal strm >|= List.length in
+  Alcotest.(check' int) ~msg ~expected ~actual;
+
+  let msg = "expected success error" in
+  let expected = Ok () in
+  let* actual = Lwt_stream.next strm in
+  Alcotest.(check' attempt_u) ~msg ~expected ~actual;
+
+  let msg = "expected stream to be empty" in
+  let+ stream_is_empty = Lwt_stream.is_empty strm in
+  Alcotest.(check' bool) ~msg ~expected:true ~actual:stream_is_empty
+
+let test_n_times_0_runs_once _switch () =
+  let operation () = Lwt.return_error (`Retry ()) in
+  let msg = "expected a retry error" in
+  let expected = Error (`Retry ()) in
+  let+ actual = Retry.(operation |> on_error |> n_times 0) in
+  Alcotest.(check' attempt_u) ~msg ~expected ~actual
+
+let test_n_times_fatal _switch () =
+  let i = ref 0 in
+  let operation () =
+    if !i < 3 then (
+      incr i;
+      Lwt.return_error (`Retry ())
+    ) else
+      Lwt.return_error (`Fatal ())
+  in
+  let msg = "expected fatal error message" in
+  let expected = Error (`Fatal ()) in
+  let+ actual = Retry.(operation |> on_error |> n_times 5) in
+  Alcotest.(check' attempt_u) ~msg ~expected ~actual
+
+let test_n_times_exhaustion _switch () =
+  let operation () = Lwt.return_error (`Retry ()) in
+  let msg = "expected exhaustion error message" in
+  let expected = Error (`Retry ()) in
+  let+ actual = Retry.(operation |> on_error |> n_times 5) in
+  Alcotest.(check' attempt_u) ~msg ~expected ~actual
+
+let test_n_times_success _switch () =
+  let i = ref 0 in
+  let operation () =
+    if !i < 3 then (
+      incr i;
+      Lwt.return_error (`Retry ())
+    ) else
+      Lwt.return_ok ()
+  in
+  try Retry.(operation |> on_error |> n_times 5) >|= Result.get_ok
+  with Invalid_argument _ -> Alcotest.fail "expected Ok result"
+
+(* test that the sleeps actually do throttle the computations *)
+let test_with_sleep _switch () =
+  let duration _ = 0.1 in
+  let racing_operation = Lwt_unix.sleep (duration ()) >|= Result.ok in
+  let operation () = Lwt.return_error (`Retry ()) in
+  let retries = Retry.(operation |> on_error |> with_sleep ~duration |> n_times 5) in
+  (* If [with_sleep] is removed the test fails, as expected *)
+  let msg = "expected racing_operation to complete before the retries with sleeps" in
+  let expected = Ok () in
+  let+ actual = Lwt.choose [racing_operation; retries] in
+  Alcotest.(check' (result unit reject)) ~msg ~expected ~actual
+
+let suite =
+  [
+    Alcotest_lwt.test_case "test_pp_error" `Quick test_pp_error;
+    Alcotest_lwt.test_case "test_success_without_retry" `Quick test_success_without_retry;
+    Alcotest_lwt.test_case "test_retries" `Quick test_retries;
+    Alcotest_lwt.test_case "test_retries_before_fatal_error" `Quick test_retries_before_fatal_error;
+    Alcotest_lwt.test_case "test_retries_before_success" `Quick test_retries_before_success;
+    Alcotest_lwt.test_case "test_n_times_fatal" `Quick test_n_times_fatal;
+    Alcotest_lwt.test_case "test_n_times_exhaustion" `Quick test_n_times_exhaustion;
+    Alcotest_lwt.test_case "test_n_times_success" `Quick test_n_times_success;
+    Alcotest_lwt.test_case "test_with_sleep" `Quick test_with_sleep;
+    Alcotest_lwt.test_case "test_n_times_0_runs_once" `Quick test_n_times_0_runs_once;
+  ]

--- a/test/test_lwt_retry.mli
+++ b/test/test_lwt_retry.mli
@@ -1,0 +1,1 @@
+val suite : unit Alcotest_lwt.test_case list

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -81,7 +81,7 @@ let docker_push ~switch ~log t hash { Cluster_api.Docker.Spec.target; auth } =
     let docker_push () =
       let retries = 5 in
       let log_retryable_error (`Msg m) n = log_info @@
-        Fmt.str "Push attempt %d/%d failed with retryable error %S. Retrying in %f seconds..."
+        Fmt.str "Push attempt %d/%d failed with retryable error %S. Retrying in %.0f seconds..."
           n (retries + 1) m (Lwt_retry.default_sleep_duration n);
         (`Msg m)
       in

--- a/worker/dune
+++ b/worker/dune
@@ -20,6 +20,7 @@
    fpath
    logs
    lwt.unix
+   lwt_retry
    ocluster-api
    prometheus-app
    obuilder

--- a/worker/dune
+++ b/worker/dune
@@ -13,4 +13,15 @@
 (library
  (name cluster_worker)
  (public_name ocluster-worker)
- (libraries ocluster-api digestif fpath logs capnp-rpc-lwt lwt.unix prometheus-app cohttp-lwt-unix obuilder extunix str))
+ (libraries
+   capnp-rpc-lwt
+   cohttp-lwt-unix
+   digestif
+   fpath
+   logs
+   lwt.unix
+   ocluster-api
+   prometheus-app
+   obuilder
+   extunix
+   str))


### PR DESCRIPTION
Contributes to https://github.com/ocurrent/docker-base-images/issues/211
This is a retargeted refinement of https://github.com/ocurrent/ocurrent/pull/451

The approach proposed here provides three small, composable, Lwt combinators to offer retry logic in a flexible way. The base function, `on_error` produces a (potentially) unlimited sequence of attempts. Adding sleeps between attempts and stopping after a set number of retries is provided by small functions that consume the stream. Additionally functionality can easily be added in the similar fashion.

There is a clear recurring need for lwt-level retry logic, as documented in https://github.com/ocurrent/ocurrent/issues/450, which is why a general approach is proposed here. However, we also have a pressing need to get retries in place for the ephemeral failures from docker pushes that are eating up maintenance time. As a compromise, this utility as being added initially at the point of use, but as a relocatable library component, which we can easily promote to a shareable location when needed.

Many thanks to @mtelvers who has been a big help in thinking through what fix is need and where it should go.