### PR TITLE
Add accessor function for getting the connection to a cluster

### DIFF
--- a/ocurrent-plugin/current_ocluster.ml
+++ b/ocurrent-plugin/current_ocluster.ml
@@ -213,3 +213,5 @@ let build_obuilder ?level ?label ?cache_hint t ~pool ~src spec =
   let> spec = spec
   and> src = src in
   Raw.build_obuilder ?level ?cache_hint t ~pool ~src spec
+
+let connection { connection; _ } = connection

--- a/ocurrent-plugin/current_ocluster.mli
+++ b/ocurrent-plugin/current_ocluster.mli
@@ -80,6 +80,8 @@ val build_obuilder :
 (** [build_obuilder t ~pool ~src spec] builds [spec] in context [src] using pool [pool] within build cluster [t].
     Note: all commits in [src] must be in the same repository. *)
 
+val connection : t -> Connection.t
+
 module Raw : sig
   val build : 
     ?level:Current.Level.t ->


### PR DESCRIPTION
Merge in the accessor added by @mtelvers. This is already in use in https://github.com/shonfeder/docker-base-images/blob/25fec1424ecf757e1fdf101fb47eac15eb6460ae/src/win_ver.ml#L64 but it has only been from a vendored branch, and this change hasn't made it into the trunk.