### PR TITLE
fix test compilation in release mode

### DIFF
--- a/test/test_scheduling.ml
+++ b/test/test_scheduling.ml
@@ -867,12 +867,12 @@ let%expect_test "persist_pause" =
   Pool.release w1;
   Lwt.return_unit
 
-let pp_forget =
+let pp_forget f x =
   let pp_forget_error f = function
     | `Still_connected -> Fmt.string f "still connected"
     | `Unknown_worker -> Fmt.string f "unknown worker"
   in
-  Fmt.(result ~ok:(const string "ok")) ~error:pp_forget_error
+  Fmt.(result ~ok:(const string "ok")) ~error:pp_forget_error f x
 
 (* Forgetting workers. *)
 let%expect_test "forget" =


### PR DESCRIPTION
in release mode, ppx_expect is stripped out and this fails to build due to the value restriction:

```
File "test/test_scheduling.ml", line 870, characters 4-13:
870 | let pp_forget =
          ^^^^^^^^^
Error: The type of this expression,
       ('_weak1, [< `Still_connected | `Unknown_worker ] as '_weak2) result
       Fmt.t, contains the non-generalizable type variable(s): '_weak1,
       '_weak2. (see manual section 6.1.2)
```

An eta expansion suffices to fix it