### PR TITLE
worker: make --obuilder-store optional again

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ cache partition (e.g. `/var/lib/docker` for Docker builds) before the worker
 will prune things (e.g. with `docker system prune -af`).
 If not given, then the worker will not monitor free space.
 
+Such a worker handles Docker jobs only, and rejects OBuilder ones.
+To take OBuilder jobs too, add `--obuilder-store` (e.g. `--obuilder-store=btrfs:/var/lib/ocluster-worker/obuilder`);
+see `ocluster-worker --help` for the available store types.
+
 The builder connects to the scheduler and waits for jobs.
 You should see `worker [INFO] Requesting a new job…` in the worker log,
 and `Registered new worker "my-host"` in the scheduler log.

--- a/bin/worker.ml
+++ b/bin/worker.ml
@@ -173,23 +173,42 @@ let additional_metrics =
     ["additional-metrics"]
 
 module Obuilder_config = struct
-  (** Parse cli arguments for Obuilder.Store_spec.t *)
-  let v =
-    let open Obuilder.Store_spec in
+  (** Parse cli arguments for [Obuilder.Store_spec.t option].
+
+      OBuilder support is optional: without [--obuilder-store] the worker still
+      handles Docker jobs and rejects OBuilder ones. We therefore can't use
+      [Obuilder.Store_spec.of_t] directly, as it raises [Failure] when no store
+      is given. *)
+  let spec =
+    let of_t store rsync_mode =
+      match store, rsync_mode with
+      | None, None -> Ok None                       (* No OBuilder support. *)
+      | None, Some _ ->
+        Error "--rsync-mode requires --obuilder-store=rsync:/path"
+      | Some (`Rsync _), None ->
+        Error "--obuilder-store=rsync:/path also requires --rsync-mode"
+      | Some (`Rsync _), Some _ ->
+        Ok (Some (Obuilder.Store_spec.of_t store rsync_mode))
+      | Some _, Some _ ->
+        Error "--rsync-mode can only be used with --obuilder-store=rsync:/path"
+      | Some _, None -> Ok (Some (Obuilder.Store_spec.of_t store None))
+    in
+    Term.term_result' @@
     Term.(const of_t
-          $ Arg.value @@ store ~docs:"OBUILDER" ["obuilder-store"]
-          $ Arg.value @@ rsync_mode_opt)
+          $ Arg.value @@ Obuilder.Store_spec.store ~docs:"OBUILDER" ["obuilder-store"]
+          $ Arg.value @@ Obuilder.Store_spec.rsync_mode_opt)
 
-  (** Parse cli arguments for t and initialise a [store]. *)
+  (** Parse cli arguments for t and initialise a [store], if requested. *)
   let cmdliner =
-    Term.(const Obuilder.Store_spec.to_store $ v)
+    Term.(const (Option.map Obuilder.Store_spec.to_store) $ spec)
 
   let v =
-    let make native_conf docker_conf qemu_conf hcs_conf = function
-      | `Native, store -> Some (Cluster_worker.Obuilder_config.v (`Native native_conf) store)
-      | `Qemu, store -> Some (Cluster_worker.Obuilder_config.v (`Qemu qemu_conf) store)
-      | `Docker, store -> Some (Cluster_worker.Obuilder_config.v (`Docker docker_conf) store)
-      | `Hcs, store -> Some (Cluster_worker.Obuilder_config.v (`Hcs hcs_conf) store)
+    let make native_conf docker_conf qemu_conf hcs_conf =
+      Option.map (function
+          | `Native, store -> Cluster_worker.Obuilder_config.v (`Native native_conf) store
+          | `Qemu, store -> Cluster_worker.Obuilder_config.v (`Qemu qemu_conf) store
+          | `Docker, store -> Cluster_worker.Obuilder_config.v (`Docker docker_conf) store
+          | `Hcs, store -> Cluster_worker.Obuilder_config.v (`Hcs hcs_conf) store)
     in
     Term.(const make $ Obuilder.Native_sandbox.cmdliner $ Obuilder.Docker_sandbox.cmdliner $ Obuilder.Qemu_sandbox.cmdliner $ Obuilder.Hcs_sandbox.cmdliner $ cmdliner)
 end

--- a/bin/worker.ml
+++ b/bin/worker.ml
@@ -176,22 +176,22 @@ module Obuilder_config = struct
   (** Parse cli arguments for [Obuilder.Store_spec.t option].
 
       OBuilder support is optional: without [--obuilder-store] the worker still
-      handles Docker jobs and rejects OBuilder ones. We therefore can't use
-      [Obuilder.Store_spec.of_t] directly, as it raises [Failure] when no store
-      is given. *)
+      handles Docker jobs and rejects OBuilder ones. Only that case is handled
+      here; a store that is given is validated by
+      [Obuilder.Store_spec.of_t]. *)
   let spec =
     let of_t store rsync_mode =
       match store, rsync_mode with
       | None, None -> Ok None                       (* No OBuilder support. *)
       | None, Some _ ->
         Error "--rsync-mode requires --obuilder-store=rsync:/path"
-      | Some (`Rsync _), None ->
-        Error "--obuilder-store=rsync:/path also requires --rsync-mode"
-      | Some (`Rsync _), Some _ ->
-        Ok (Some (Obuilder.Store_spec.of_t store rsync_mode))
-      | Some _, Some _ ->
-        Error "--rsync-mode can only be used with --obuilder-store=rsync:/path"
-      | Some _, None -> Ok (Some (Obuilder.Store_spec.of_t store None))
+      | Some _, _ ->
+        (* Which stores need an rsync-mode is OBuilder's business, not ours.
+           of_t signals a bad combination by raising, so present that as a
+           command-line error rather than an uncaught exception. *)
+        (match Obuilder.Store_spec.of_t store rsync_mode with
+         | store -> Ok (Some store)
+         | exception Failure m -> Error m)
     in
     Term.term_result' @@
     Term.(const of_t


### PR DESCRIPTION
Fixes the README command in #263, which died with an uncaught `Failure("Store type required must be one of btrfs:/path, …")`.

`Obuilder.Store_spec.of_t` raises when given no store, and the term applied it unconditionally — so `--obuilder-store` was effectively mandatory. But a worker without an OBuilder store is a supported configuration: `Cluster_worker.run` takes `?obuilder` and rejects OBuilder jobs with *"This worker is not configured for use with OBuilder!"* when it is absent.

The store is now parsed into an option, and the invalid store/`--rsync-mode` combinations are reported as ordinary command-line errors instead of uncaught exceptions:

| Command | Before | After |
| --- | --- | --- |
| README command (no store) | `internal error, uncaught exception: Failure("Store type required…")` | starts, connects to the scheduler |
| `--obuilder-store=rsync:/p` | uncaught `Failure("Store rsync:/ must supply an rsync-mode")` | `--obuilder-store=rsync:/path also requires --rsync-mode` |
| `--obuilder-store=btrfs:/p --rsync-mode=copy` | uncaught `Failure("Store type required…")`, though the store was valid | `--rsync-mode can only be used with --obuilder-store=rsync:/path` |
| `--rsync-mode=copy` alone | uncaught `Failure("Store type required…")` | `--rsync-mode requires --obuilder-store=rsync:/path` |

`--obuilder-store=docker:/p` still starts as before. The README now says that `--obuilder-store` is what enables OBuilder jobs.

ocurrent/obuilder#218 fixes the misleading messages on the OBuilder side, but is not needed for this.

Closes #263