### PR TITLE
Support Prometheus 1.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,9 @@
 ### unreleased
 
-- Support Prometheus 1.4 (@mtelvers #265)
-  Prometheus 1.4 splits the Lwt-typed functions out of the `prometheus` core
-  into a new `prometheus-lwt` package and deprecates the originals. Migrate to
-  `Prometheus_lwt.CollectorRegistry.collect` and
-  `Prometheus_lwt.Summary.observe_time`, which takes its clock from
-  `Prometheus.init` rather than an explicit `gettime` argument.
+- Migrate to Prometheus 1.4 and the new prometheus-lwt package (@mtelvers #265)
+- Update the vendored obuilder to v0.7.0-27-g0ad23d4 (@mtelvers #265)
+- Move all three Dockerfiles to one opam-repository SHA, with opam 2.5 (@mtelvers #265)
+- Fix the scheduler Docker image build (@mtelvers #265)
 
 ### v0.4.0 (2026-05-13)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+### unreleased
+
+- Support Prometheus 1.4 (@mtelvers #265)
+  Prometheus 1.4 splits the Lwt-typed functions out of the `prometheus` core
+  into a new `prometheus-lwt` package and deprecates the originals. Migrate to
+  `Prometheus_lwt.CollectorRegistry.collect` and
+  `Prometheus_lwt.Summary.observe_time`, which takes its clock from
+  `Prometheus.init` rather than an explicit `gettime` argument.
+
 ### v0.4.0 (2026-05-13)
 
 - Fix test compilation in release mode (@avsm #262, reviewed by @mtelvers)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM ocaml/opam:debian-13-ocaml-4.14 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto libcapnp-dev m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN sudo ln -f /usr/bin/opam-2.4 /usr/bin/opam && opam init --reinit -ni
+RUN sudo ln -f /usr/bin/opam-2.5 /usr/bin/opam && opam init --reinit -ni
 RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 3e2ef3aff96fed8cfa47af6ea93970d3ff8c1c10 && opam update
 COPY --chown=opam ocluster-api.opam ocluster-worker.opam ocluster.opam /src/
 COPY --chown=opam obuilder/obuilder.opam obuilder/obuilder-spec.opam /src/obuilder/
-RUN opam pin -yn /src/obuilder/
 WORKDIR /src
+RUN echo '(lang dune 3.0)' | \
+    tee obuilder/dune-project | \
+    tee ./dune-project
+RUN opam pin -yn /src/obuilder/
 RUN opam install -y --deps-only .
 ADD --chown=opam . .
 RUN opam exec -- dune subst

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-13-ocaml-4.14 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto libcapnp-dev m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
 RUN sudo ln -f /usr/bin/opam-2.4 /usr/bin/opam && opam init --reinit -ni
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 5d3f0d1d655199e596a1e785e69fae8fad78cad3 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 3e2ef3aff96fed8cfa47af6ea93970d3ff8c1c10 && opam update
 COPY --chown=opam ocluster-api.opam ocluster-worker.opam ocluster.opam /src/
 COPY --chown=opam obuilder/obuilder.opam obuilder/obuilder-spec.opam /src/obuilder/
 RUN opam pin -yn /src/obuilder/

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-13-ocaml-4.14 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto libcapnp-dev m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
 RUN sudo ln -f /usr/bin/opam-2.5 /usr/bin/opam && opam init --reinit -ni
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard fde524a7a5fc26108522edaefc3bcf346adb744a && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 3e2ef3aff96fed8cfa47af6ea93970d3ff8c1c10 && opam update
 COPY --chown=opam ocluster-api.opam ocluster-worker.opam ocluster.opam /src/
 COPY --chown=opam obuilder/obuilder.opam obuilder/obuilder-spec.opam /src/obuilder/
 WORKDIR /src

--- a/Dockerfile.worker.alpine
+++ b/Dockerfile.worker.alpine
@@ -1,7 +1,7 @@
 FROM ocaml/opam:alpine-ocaml-4.14 AS build
 RUN sudo apk update && sudo apk add libev capnproto m4 sqlite libgmpxx
 RUN sudo ln -f /usr/bin/opam-2.5 /usr/bin/opam && opam init --reinit -ni
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard fde524a7a5fc26108522edaefc3bcf346adb744a && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 3e2ef3aff96fed8cfa47af6ea93970d3ff8c1c10 && opam update
 COPY --chown=opam ocluster-api.opam ocluster-worker.opam ocluster.opam /src/
 COPY --chown=opam obuilder/obuilder.opam obuilder/obuilder-spec.opam /src/obuilder/
 WORKDIR /src

--- a/bin/dune
+++ b/bin/dune
@@ -2,7 +2,7 @@
  (public_names ocluster-scheduler ocluster-client ocluster-worker ocluster-admin)
  (package ocluster)
  (names scheduler client worker admin)
- (libraries dune-build-info ocluster-api logs.cli logs.fmt fmt.cli fmt.tty capnp-rpc-unix cluster_scheduler ocluster-worker prometheus-app.unix db
+ (libraries dune-build-info ocluster-api logs.cli logs.fmt fmt.cli fmt.tty capnp-rpc-unix cluster_scheduler ocluster-worker prometheus-app.unix prometheus-lwt db
   (select winsvc_wrapper.ml from
    (winsvc -> winsvc_wrapper.winsvc.ml)
    (       -> winsvc_wrapper..ml))))

--- a/bin/scheduler.ml
+++ b/bin/scheduler.ml
@@ -68,7 +68,7 @@ module Web = struct
     let uri = Request.uri req in
     match Request.meth req, Astring.String.cuts ~empty:false ~sep:"/" (Uri.path uri) with
     | `GET, ["metrics"] ->
-      Prometheus.CollectorRegistry.(collect default) >>= fun data ->
+      Prometheus_lwt.CollectorRegistry.(collect default) >>= fun data ->
       let body = Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output data in
       let headers = Header.init_with "Content-Type" "text/plain; version=0.0.4" in
       Server.respond_string ~status:`OK ~headers ~body ()

--- a/current_ocluster.opam
+++ b/current_ocluster.opam
@@ -31,7 +31,7 @@ depends: [
   "lwt" {>= "5.7.0"}
   "ppx_deriving"
   "ppx_deriving_yojson"
-  "prometheus" {>= "1.2"}
+  "prometheus" {>= "1.4"}
   "current_github" {>= "0.6.4" & with-test}
   "current_web" {>= "0.6.4" & with-test}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -44,7 +44,8 @@
   logs
   (lwt (>= 5.7.0))
   (obuilder (>= 0.7.0))
-  (prometheus-app (>= 1.2))))
+  (prometheus-app (>= 1.4))
+  (prometheus-lwt (>= 1.4))))
 
 (package
  (name ocluster)
@@ -70,8 +71,9 @@
   (obuilder (>= 0.7.0))
   (ppx_expect (>= v0.14.1))
   ppx_sexp_conv
-  prometheus
-  (prometheus-app (>= 1.2))
+  (prometheus (>= 1.4))
+  (prometheus-app (>= 1.4))
+  (prometheus-lwt (>= 1.4))
   (psq (>= 0.2.1))
   sqlite3
   (winsvc (and (>= 1.0.1) (= :os "win32")))
@@ -98,6 +100,6 @@
   (lwt (>= 5.7.0))
   ppx_deriving
   ppx_deriving_yojson
-  (prometheus (>= 1.2))
+  (prometheus (>= 1.4))
   (current_github (and (>= 0.6.4) :with-test))
   (current_web (and (>= 0.6.4) :with-test))))

--- a/ocluster-worker.opam
+++ b/ocluster-worker.opam
@@ -29,7 +29,8 @@ depends: [
   "logs"
   "lwt" {>= "5.7.0"}
   "obuilder" {>= "0.7.0"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus-app" {>= "1.4"}
+  "prometheus-lwt" {>= "1.4"}
   "odoc" {with-doc}
 ]
 build: [

--- a/ocluster.opam
+++ b/ocluster.opam
@@ -47,8 +47,9 @@ depends: [
   "obuilder" {>= "0.7.0"}
   "ppx_expect" {>= "v0.14.1"}
   "ppx_sexp_conv"
-  "prometheus"
-  "prometheus-app" {>= "1.2"}
+  "prometheus" {>= "1.4"}
+  "prometheus-app" {>= "1.4"}
+  "prometheus-lwt" {>= "1.4"}
   "psq" {>= "0.2.1"}
   "sqlite3"
   "winsvc" {>= "1.0.1" & os = "win32"}

--- a/test/dune
+++ b/test/dune
@@ -14,7 +14,8 @@
     fmt.tty
     logs.fmt
     lwt.unix
-    prometheus-app))
+    prometheus-app
+    prometheus-lwt))
 
 (library
   (name ocluster_expect_tests)
@@ -28,4 +29,5 @@
     fmt.tty
     logs.fmt
     lwt.unix
-    prometheus-app))
+    prometheus-app
+    prometheus-lwt))

--- a/test/test_plugin.ml
+++ b/test/test_plugin.ml
@@ -228,7 +228,7 @@ let cancel_rate_limit () =
 let test_case name fn =
   Alcotest_lwt.test_case name `Quick @@ fun _ () ->
   fn () >>= fun () ->
-  Prometheus.CollectorRegistry.(collect default) >|= fun data ->
+  Prometheus_lwt.CollectorRegistry.(collect default) >|= fun data ->
   Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output data
   |> String.split_on_char '\n'
   |> List.iter (fun line ->

--- a/test/test_scheduling.ml
+++ b/test/test_scheduling.ml
@@ -60,7 +60,7 @@ let run fn =
     Fake_time.now := 1.0;
     fn () >>= fun () ->
     Lwt.pause () >>= fun () ->
-    Prometheus.CollectorRegistry.(collect default) >|= fun data ->
+    Prometheus_lwt.CollectorRegistry.(collect default) >|= fun data ->
     Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output data
     |> String.split_on_char '\n'
     |> List.iter (fun line ->

--- a/worker/cluster_worker.ml
+++ b/worker/cluster_worker.ml
@@ -137,7 +137,7 @@ let build ~switch ~log t descr =
         match push_to with
         | None -> Lwt_result.return ""
         | Some target ->
-          Prometheus.Summary.time Metrics.docker_push_time Unix.gettimeofday
+          Prometheus_lwt.Summary.observe_time Metrics.docker_push_time
             (fun () -> docker_push ~switch ~log t hash target)
       end
     | Obuilder_build { spec = `Contents spec } ->
@@ -215,7 +215,7 @@ let rec maybe_prune t queue =
     in
     drain () >>= fun () ->
     Log.info (fun f -> f "All jobs finished. Pruning…");
-    Prometheus.Summary.time Metrics.docker_prune_time Unix.gettimeofday
+    Prometheus_lwt.Summary.observe_time Metrics.docker_prune_time
       (fun () ->
          Lwt_process.exec ("", [| "docker"; "system"; "prune"; "-af" |]) >>= function
          | Unix.WEXITED 0 ->
@@ -458,7 +458,7 @@ let collect_external_metric uri =
 
 let metrics = function
   | `Agent ->
-    Prometheus.CollectorRegistry.(collect default) >>= fun data ->
+    Prometheus_lwt.CollectorRegistry.(collect default) >>= fun data ->
     let content_type = "text/plain; version=0.0.4; charset=utf-8" in
     Lwt_result.return (content_type, Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output data)
   | `Host ->

--- a/worker/dune
+++ b/worker/dune
@@ -23,6 +23,7 @@
    lwt_retry
    ocluster-api
    prometheus-app
+   prometheus-lwt
    obuilder
    extunix
    str))


### PR DESCRIPTION
Prometheus 1.4 moves the Lwt-typed functions out of the `prometheus` core into a new `prometheus-lwt` package and deprecates the originals, which breaks the build here.

- `CollectorRegistry.collect` -> `Prometheus_lwt.CollectorRegistry.collect`; `Summary.time m Unix.gettimeofday` -> `Prometheus_lwt.Summary.observe_time m`. The clock now comes from `Prometheus.init`; still seconds.
- Bump prometheus bounds to 1.4, add `prometheus-lwt`.
- Move all three Dockerfiles to one opam-repository SHA carrying 1.4, and the scheduler to opam 2.5.
- Update vendored obuilder to v0.7.0-27-g0ad23d4 (was v0.5.1-109, below the declared `>= 0.7.0`).

The scheduler image was already broken on master, unrelated to prometheus: the Oct 2024 pin predates `ocaml-base-compiler.4.14.3`, and `obuilder-spec` then fails `dune subst` with no `dune-project` in `/src/obuilder`. Both fixed; CI doesn't build these images, hence unnoticed.

`dune build` clean, 33/33 tests pass, all three images build.
